### PR TITLE
Replace unnecessary git references with generic terms

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,11 +251,11 @@ Release workflow tools for creating versioned releases with auto-generated notes
 | Component | Trigger | Description |
 |-----------|---------|-------------|
 | skill | `/release-tools:new` | Create GitHub/GitLab/Gitea release with auto-versioning and release notes |
-| skill | `/release-tools:last-tag` | Show commits since the last git tag in a formatted table |
+| skill | `/release-tools:last-tag` | Show commits since the last tag in a formatted table |
 
 **release** — full release workflow: asks release type (hotfix/minor/major), auto-detects platform (GitHub/GitLab/Gitea), calculates semantic version, generates release notes grouped by type (features/improvements/fixes) from merged PRs and commits, updates CHANGELOG if present, shows preview for confirmation, then publishes. Includes helper scripts for platform detection, version calculation, and notes generation.
 
-**last-tag** — shows commits since the last git tag in a formatted table with date, author, hash, and description. Detects single vs multiple authors and adjusts table layout. Offers interactive drill-down into individual commit details.
+**last-tag** — shows commits since the last tag in a formatted table with date, author, hash, and description. Detects single vs multiple authors and adjusts table layout. Offers interactive drill-down into individual commit details.
 
 ### thinking-tools
 

--- a/plugins/planning/commands/make.md
+++ b/plugins/planning/commands/make.md
@@ -267,7 +267,7 @@ then use AskUserQuestion:
       {"label": "Auto review", "description": "Launch AI plan-review agent for automated analysis"},
       {"label": "Start implementation", "description": "Commit plan and begin implementing task by task (interactive, in this session)"},
       {"label": "Execute autonomously", "description": "Commit plan and run /planning:exec for autonomous execution with reviews"},
-      {"label": "Done", "description": "Commit plan to git, no further action"}
+      {"label": "Done", "description": "Commit plan, no further action"}
     ],
     "multiSelect": false
   }]

--- a/plugins/planning/skills/exec/references/prompts/progress-file.md
+++ b/plugins/planning/skills/exec/references/prompts/progress-file.md
@@ -50,5 +50,5 @@ Completed: <timestamp>
 ## How to pass it
 
 - Pass the progress file path to the fixer agent prompt — add it after the plan file reference
-- Review agents do NOT need the progress file (they look at git state)
+- Review agents do NOT need the progress file (they look at repository state)
 - The fixer uses it to understand what previous iterations found and fixed

--- a/plugins/release-tools/skills/last-tag/SKILL.md
+++ b/plugins/release-tools/skills/last-tag/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: last-tag
-description: Show commits since the last git tag in a formatted table. Use when user asks "what changed since last release", "commits since last tag", "last-tag", "what's new", or wants to see recent unreleased changes.
+description: Show commits since the last tag in a formatted table. Use when user asks "what changed since last release", "commits since last tag", "last-tag", "what's new", or wants to see recent unreleased changes.
 allowed-tools: Bash, AskUserQuestion
 ---
 
 # Last Tag - Commits Since Last Release
 
-Show commits since the last git tag in a formatted table with optional details.
+Show commits since the last tag in a formatted table with optional details.
 
 ## Activation Triggers
 


### PR DESCRIPTION
## Summary

Preparation for future mercurial (hg) support. Removes "git" from prose descriptions where it adds no meaning:

- "Commit plan to git" → "Commit plan"
- "last git tag" → "last tag" (4 places across README and SKILL.md)
- "git state" → "repository state"

Actual git commands in scripts/code blocks and git-specific tool names (git-review, git worktree) are intentionally left unchanged.