### PR TITLE
add cmux and ghostty terminal support to plan review launcher

### DIFF
--- a/plugins/planning/scripts/launch-plan-review.sh
+++ b/plugins/planning/scripts/launch-plan-review.sh
@@ -78,5 +78,84 @@ if [ -n "${WEZTERM_PANE:-}" ] && command -v wezterm >/dev/null 2>&1; then
     exit 0
 fi
 
-echo "error: no overlay terminal available (requires tmux, kitty, or wezterm)" >&2
+# cmux: split pane via cmux CLI (must precede ghostty — cmux also sets TERM_PROGRAM=ghostty)
+if [ -n "${CMUX_SURFACE_ID:-}" ] && command -v cmux >/dev/null 2>&1; then
+    SENTINEL=$(mktemp /tmp/plan-review-done-XXXXXX)
+    rm -f "$SENTINEL"
+
+    LAUNCH_SCRIPT=$(mktemp /tmp/plan-review-launch-XXXXXX)
+    trap 'rm -f "$OUTPUT_FILE" "$SENTINEL" "$LAUNCH_SCRIPT"' EXIT
+    cat > "$LAUNCH_SCRIPT" <<LAUNCHER
+#!/bin/sh
+$REVDIFF_CMD; touch '$SENTINEL'
+LAUNCHER
+    chmod +x "$LAUNCH_SCRIPT"
+
+    CMUX_NEW=$(cmux new-split down 2>&1) || true
+    CMUX_SURF=$(echo "$CMUX_NEW" | grep -o 'surface:[0-9]*' | head -1)
+
+    if [ -n "$CMUX_SURF" ]; then
+        cmux send --surface "$CMUX_SURF" "exec $LAUNCH_SCRIPT\n"
+    else
+        cmux send "exec $LAUNCH_SCRIPT\n"
+    fi
+
+    while [ ! -f "$SENTINEL" ]; do
+        sleep 0.3
+    done
+    if [ -n "$CMUX_SURF" ]; then
+        cmux close-surface --surface "$CMUX_SURF" 2>/dev/null || true
+    fi
+    rm -f "$SENTINEL" "$LAUNCH_SCRIPT"
+    cat "$OUTPUT_FILE"
+    exit 0
+fi
+
+# ghostty: split pane via AppleScript (macOS only, requires Ghostty 1.3.0+)
+if [ "${TERM_PROGRAM:-}" = "ghostty" ] && command -v osascript >/dev/null 2>&1; then
+    SENTINEL=$(mktemp /tmp/plan-review-done-XXXXXX)
+    rm -f "$SENTINEL"
+
+    LAUNCH_SCRIPT=$(mktemp /tmp/plan-review-launch-XXXXXX)
+    trap 'rm -f "$OUTPUT_FILE" "$SENTINEL" "$LAUNCH_SCRIPT"' EXIT
+    cat > "$LAUNCH_SCRIPT" <<LAUNCHER
+#!/bin/sh
+$REVDIFF_CMD; touch '$SENTINEL'
+LAUNCHER
+    chmod +x "$LAUNCH_SCRIPT"
+
+    GHOSTTY_TERM_ID=$(osascript - "$LAUNCH_SCRIPT" <<'APPLESCRIPT'
+on run argv
+    set launchScript to item 1 of argv
+    tell application "Ghostty"
+        set cfg to new surface configuration
+        set command of cfg to launchScript
+        set wait after command of cfg to false
+        set ft to focused terminal of selected tab of front window
+        set newTerm to split ft direction down with configuration cfg
+        perform action "toggle_split_zoom" on newTerm
+        return id of newTerm
+    end tell
+end run
+APPLESCRIPT
+    )
+    if [ $? -ne 0 ]; then
+        rm -f "$SENTINEL" "$LAUNCH_SCRIPT"
+        exit 1
+    fi
+
+    while [ ! -f "$SENTINEL" ]; do
+        sleep 0.3
+    done
+    osascript - "$GHOSTTY_TERM_ID" <<'APPLESCRIPT' 2>/dev/null
+on run argv
+    tell application "Ghostty" to close terminal id (item 1 of argv)
+end run
+APPLESCRIPT
+    rm -f "$SENTINEL" "$LAUNCH_SCRIPT"
+    cat "$OUTPUT_FILE"
+    exit 0
+fi
+
+echo "error: no overlay terminal available (requires tmux, kitty, wezterm, cmux, or ghostty)" >&2
 exit 1

--- a/plugins/planning/scripts/plan-review-hook.py
+++ b/plugins/planning/scripts/plan-review-hook.py
@@ -12,7 +12,7 @@ returns PreToolUse hook JSON response with permissionDecision:
 
 requirements:
   - revdiff (preferred) or $EDITOR (fallback)
-  - tmux, kitty, or wezterm terminal
+  - tmux, kitty, wezterm, cmux, or ghostty terminal
 """
 
 import json


### PR DESCRIPTION
## Summary

[cmux](https://cmux.com) is a native macOS terminal built for AI coding agents. It's based on libghostty and sets `TERM_PROGRAM=ghostty`, which causes the existing Ghostty detection path to never be reached (cmux doesn't expose Ghostty's AppleScript API).

This PR adds cmux and ghostty as supported terminals for `launch-plan-review.sh` (the revdiff overlay launcher used by the planning plugin's `ExitPlanMode` hook):

- **cmux** — detected via `$CMUX_SURFACE_ID` env var. Uses the cmux CLI: `cmux new-split down` to create a split pane, `cmux send --surface <ref>` to target it, `cmux close-surface` to clean up after
- **ghostty** — detected via `$TERM_PROGRAM=ghostty` + `osascript`. Uses AppleScript to split the terminal pane, zoom it, and close on exit
- cmux block placed **before** ghostty to prevent the false Ghostty match

## Changes

- `plugins/planning/scripts/launch-plan-review.sh` — cmux and ghostty blocks added after wezterm
- `plugins/planning/scripts/plan-review-hook.py` — terminal list updated in requirements comment

## Notes

- cmux's `new-split` doesn't accept a `--command` argument, so a temp launch script is created and sent via `cmux send "exec $LAUNCH_SCRIPT\n"`. The pty input buffer holds the text until the new pane's shell initializes and reads it — no sleep or retry needed.
- `exec $LAUNCH_SCRIPT` replaces the interactive shell so the pane closes automatically when revdiff exits.
- Surface ref is parsed from `cmux new-split` output (`OK surface:N ...`) and used for targeted `send` and `close-surface`.
- macOS `mktemp` requires X's at the end of the template — the `.sh` suffix was dropped to avoid literal filename creation.

## Test plan

- [x] Tested in cmux — split opens, revdiff TUI launches, annotations captured, split closes on quit
- [x] Existing tests pass: `python3 plugins/planning/scripts/plan-annotate.py --test`
- [x] No regression on tmux/kitty/wezterm (cmux/ghostty blocks are after all three)