### PR TITLE
Add Ghostty terminal overlay support

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ PR review, interactive git diff annotation review, and writing style tools. Inst
 
 Uses `gh` CLI for all GitHub operations and git worktrees to avoid disrupting the current checkout.
 
-**git-review** — interactive annotation-based code review. Generates a cleaned-up diff, opens it in `$EDITOR` via tmux popup, kitty overlay, or wezterm split-pane. You annotate directly in the diff, and the script returns your changes as a git diff. Claude reads annotations, fixes code, regenerates the diff, and loops until you close the editor without changes. Supports auto-detection of uncommitted changes or branch diffs.
+**git-review** — interactive annotation-based code review. Generates a cleaned-up diff, opens it in `$EDITOR` via tmux popup, kitty overlay, wezterm split-pane, or ghostty split. You annotate directly in the diff, and the script returns your changes as a git diff. Claude reads annotations, fixes code, regenerates the diff, and loops until you close the editor without changes. Supports auto-detection of uncommitted changes or branch diffs.
 
 Run tests: `python3 plugins/review/skills/git-review/scripts/git-review.py --test`
 
@@ -203,17 +203,19 @@ Structured implementation planning with interactive annotation review and autono
 - **Step 2** — creates the plan file with tasks, file lists, test requirements, and progress tracking
 - **Step 3** — offers interactive review (opens plan in `$EDITOR` via plan-annotate), auto review, start implementation, or done
 
-**plan-annotate.py** — interactive plan annotation tool. Opens plans in your `$EDITOR` via a terminal overlay (tmux popup, kitty overlay, or wezterm split-pane), lets you annotate directly, and feeds a unified diff back to Claude so it revises the plan. Two modes:
+**plan-annotate.py** — interactive plan annotation tool. Opens plans in your `$EDITOR` via a terminal overlay (tmux popup, kitty overlay, wezterm split-pane, or ghostty split), lets you annotate directly, and feeds a unified diff back to Claude so it revises the plan. Two modes:
 
 - *Hook mode* (default) — intercepts `ExitPlanMode`, opens plan in editor, denies tool call with diff if changes made, forcing revision loop
 - *File mode* (`plan-annotate.py <plan-file>`) — outputs unified diff to stdout for integration with custom workflows
 
-Requirements: tmux, kitty, or wezterm terminal, `$EDITOR` (defaults to `micro`). **Kitty users** must enable remote control in `kitty.conf`:
+Requirements: tmux, kitty, wezterm, or ghostty terminal, `$EDITOR` (defaults to `micro`). **Kitty users** must enable remote control in `kitty.conf`:
 
 ```
 allow_remote_control yes
 listen_on unix:/tmp/kitty-$KITTY_PID
 ```
+
+**Ghostty users**: requires Ghostty 1.3.0+ on macOS (uses AppleScript to create splits).
 
 Run tests: `python3 plugins/planning/hooks/plan-annotate.py --test`
 

--- a/docs/plans/20260418-ghostty-overlay-support.md
+++ b/docs/plans/20260418-ghostty-overlay-support.md
@@ -188,15 +188,15 @@ The revdiff reference prepends `/usr/bin/env EDITOR=... VISUAL=...` to the launc
 - Modify: `plugins/planning/scripts/plan-review-hook.py` (docstring mentions terminals)
 - Modify: `plugins/review/skills/git-review/SKILL.md` (if it mentions terminal requirements)
 
-- [ ] Run a broader grep to catch all phrasings (comma-separated, slash-separated, "or"): `grep -rEn "tmux[, /]|kitty[, /]|wezterm[, /]" plugins/ README.md` — update each hit to include ghostty.
-- [ ] Explicit docstring surfaces to update (line numbers may shift as Tasks 2/3 land; reference by section):
+- [x] Run a broader grep to catch all phrasings (comma-separated, slash-separated, "or"): `grep -rEn "tmux[, /]|kitty[, /]|wezterm[, /]" plugins/ README.md` — update each hit to include ghostty.
+- [x] Explicit docstring surfaces to update (line numbers may shift as Tasks 2/3 land; reference by section):
   - `plan-annotate.py` module docstring: the `(tmux or kitty)` parenthetical in the first paragraph, the `terminal priority:` arrow list (`tmux display-popup → kitty overlay → wezterm split-pane → ghostty split → error`), the `requirements` list, and the `limitations` list (`does not work in plain terminals`).
   - `git-review.py` module docstring: the `tmux/kitty/wezterm overlay` slash-separated form.
   - `plan-review-hook.py` docstring `requirements` line: `tmux, kitty, wezterm, or ghostty terminal`.
-- [ ] In `README.md`, find the planning and review plugin descriptions; update terminal requirement phrasing.
-- [ ] Ensure wording is consistent across all files (use the same canonical phrase: `tmux, kitty, wezterm, or ghostty`).
-- [ ] Add a brief one-line note in the appropriate reference/README that Ghostty requires 1.3.0+ on macOS. Place it where other terminal-specific caveats (e.g., kitty `allow_remote_control`) already live.
-- [ ] Final verification grep: `grep -rEn "tmux[, /]|kitty[, /]|wezterm[, /]" plugins/ README.md` should show ghostty included in every user-facing hit (vendored files, completed plans, and git history references are excluded).
+- [x] In `README.md`, find the planning and review plugin descriptions; update terminal requirement phrasing.
+- [x] Ensure wording is consistent across all files (use the same canonical phrase: `tmux, kitty, wezterm, or ghostty`).
+- [x] Add a brief one-line note in the appropriate reference/README that Ghostty requires 1.3.0+ on macOS. Place it where other terminal-specific caveats (e.g., kitty `allow_remote_control`) already live.
+- [x] Final verification grep: `grep -rEn "tmux[, /]|kitty[, /]|wezterm[, /]" plugins/ README.md` should show ghostty included in every user-facing hit (vendored files, completed plans, and git history references are excluded).
 
 ### Task 5: Bump plugin versions
 

--- a/docs/plans/20260418-ghostty-overlay-support.md
+++ b/docs/plans/20260418-ghostty-overlay-support.md
@@ -170,14 +170,14 @@ The revdiff reference prepends `/usr/bin/env EDITOR=... VISUAL=...` to the launc
 **Files:**
 - Modify: `plugins/review/skills/git-review/scripts/git-review.py`
 
-- [ ] Add ghostty branch inside `open_editor()` after the wezterm branch, before `return 1` (around line 312).
-- [ ] Mirror the Task 2 implementation — same cmux-guarded gate, launcher file, osascript pattern.
-- [ ] Use prefix `"review-done-"` for sentinel to match existing git-review.py naming (NOT `plan-done-` from Task 2).
-- [ ] Set AppleScript title/context to match — no title is shown for Ghostty splits, so no title parameter needed.
-- [ ] Update the function docstring (line 258): `tries tmux first (if $TMUX is set), then kitty, then wezterm, then ghostty.`.
-- [ ] Update the error message in `run_review` (line 373): `"error: no overlay terminal available (requires tmux, kitty, wezterm, or ghostty)"`.
-- [ ] Run any existing tests: there are no `--test` flag tests in git-review.py beyond `run_tests()` — confirm by inspection.
-- [ ] Manual verify: inside a git repo with changes, launch `/review:git-review` from Ghostty; editor opens in split pane, annotations diff is printed on close.
+- [x] Add ghostty branch inside `open_editor()` after the wezterm branch, before `return 1` (around line 312).
+- [x] Mirror the Task 2 implementation — same cmux-guarded gate, launcher file, osascript pattern.
+- [x] Use prefix `"review-done-"` for sentinel to match existing git-review.py naming (NOT `plan-done-` from Task 2).
+- [x] Set AppleScript title/context to match — no title is shown for Ghostty splits, so no title parameter needed.
+- [x] Update the function docstring (line 258): `tries tmux first (if $TMUX is set), then kitty, then wezterm, then ghostty.`.
+- [x] Update the error message in `run_review` (line 373): `"error: no overlay terminal available (requires tmux, kitty, wezterm, or ghostty)"`.
+- [x] Run any existing tests: there are no `--test` flag tests in git-review.py beyond `run_tests()` — confirm by inspection.
+- [x] manual verify (skipped - not automatable): inside a git repo with changes, launch `/review:git-review` from Ghostty; editor opens in split pane, annotations diff is printed on close.
 
 ### Task 4: Update user-facing documentation
 

--- a/docs/plans/20260418-ghostty-overlay-support.md
+++ b/docs/plans/20260418-ghostty-overlay-support.md
@@ -204,9 +204,9 @@ The revdiff reference prepends `/usr/bin/env EDITOR=... VISUAL=...` to the launc
 - Modify: `plugins/planning/.claude-plugin/plugin.json`
 - Modify: `plugins/review/.claude-plugin/plugin.json`
 
-- [ ] Bump `plugins/planning/.claude-plugin/plugin.json` version `3.4.0` → `3.5.0` (minor: new terminal support = new feature per CLAUDE.md versioning guidance).
-- [ ] Bump `plugins/review/.claude-plugin/plugin.json` version `2.2.1` → `2.3.0` (same reasoning).
-- [ ] Do NOT change marketplace.json (no structural changes).
+- [x] Bump `plugins/planning/.claude-plugin/plugin.json` version `3.4.0` → `3.5.0` (minor: new terminal support = new feature per CLAUDE.md versioning guidance).
+- [x] Bump `plugins/review/.claude-plugin/plugin.json` version `2.2.1` → `2.3.0` (same reasoning).
+- [x] Do NOT change marketplace.json (no structural changes).
 
 ### Task 6: Verify acceptance criteria
 - [ ] All three scripts now detect Ghostty and open a split pane instead of erroring out.

--- a/docs/plans/20260418-ghostty-overlay-support.md
+++ b/docs/plans/20260418-ghostty-overlay-support.md
@@ -1,0 +1,235 @@
+# Ghostty Terminal Overlay Support
+
+## Overview
+- Add Ghostty terminal overlay support to cc-thingz scripts that currently support only tmux/kitty/wezterm.
+- Users on Ghostty cannot use `/planning:make` interactive review, `plan-annotate.py` fallback, or `/review:git-review` annotation flow — all three exit with "no overlay terminal available".
+- The sibling `revdiff` repository already implements Ghostty overlay via AppleScript (`tell application "Ghostty" ... split ft direction down`) for Ghostty 1.3.0+ on macOS. This plan ports that mechanism into cc-thingz.
+
+## Context (from discovery)
+- Files with terminal overlay logic (all 3 currently lack Ghostty):
+  - `plugins/planning/scripts/launch-plan-review.sh` — bash, launches revdiff TUI; supports tmux, kitty, wezterm.
+  - `plugins/planning/scripts/plan-annotate.py` — Python, opens `$EDITOR`; supports tmux, kitty, wezterm.
+  - `plugins/review/skills/git-review/scripts/git-review.py` — Python, opens `$EDITOR`; supports tmux, kitty, wezterm.
+- Reference implementations in `../revdiff`:
+  - `.claude-plugin/skills/revdiff/scripts/launch-revdiff.sh` — full overlay support (tmux/zellij/kitty/wezterm/cmux/ghostty/iterm2/vterm).
+  - `plugins/revdiff-planning/scripts/launch-plan-review.sh` — planning-specific variant with Ghostty.
+  - `docs/plans/completed/20260405-ghostty-support.md` — prior implementation plan.
+- Ghostty detection: `TERM_PROGRAM == "ghostty"` plus `osascript` available **and** `CMUX_SURFACE_ID` unset. The cmux-guard is needed because cmux also sets `TERM_PROGRAM=ghostty`; without the guard, a cmux user would be routed to the AppleScript path and see an unexpected real-Ghostty split. Requires Ghostty 1.3.0+ (earlier versions lack `new surface configuration` AppleScript API).
+- User scoped this plan to **Ghostty only** — not adding zellij/cmux/iterm2/vterm in this pass.
+- Plugin versions to bump (minor, new terminal = new feature per CLAUDE.md's versioning guidance): `plugins/planning/.claude-plugin/plugin.json` (3.4.0 → 3.5.0), `plugins/review/.claude-plugin/plugin.json` (2.2.1 → 2.3.0).
+
+## Development Approach
+- **Testing approach**: manual verification only. Terminal overlays require a running Ghostty window — automated tests would either mock everything away (no real coverage) or need a desktop automation harness (out of scope).
+- Small, focused changes: one script per task.
+- Follow the existing block-order pattern: tmux → kitty → wezterm → **ghostty** (new) → error.
+- Ghostty block uses `TERM_PROGRAM=ghostty` + `osascript` detection (matches revdiff pattern exactly).
+- Preserve existing behavior: the error message at the bottom stays the source of truth for "what overlays are supported" — it gets updated too.
+- Update docstrings, user-facing requirements comments, and docs to mention ghostty.
+- **No new automated tests** per user decision. Each task ends with a manual verification step that the user performs.
+
+## Testing Strategy
+- **Unit tests**: none added (user chose manual-only).
+- **Manual verification per script**:
+  - Launch from a Ghostty terminal (1.3.0+, macOS). Confirm overlay opens as a split pane below with zoom enabled, blocks until closed, and returns annotations/diff correctly.
+  - Negative: run outside Ghostty (e.g., plain Terminal.app with no `TMUX`/`KITTY_LISTEN_ON`/`WEZTERM_PANE`) and confirm the clean error message lists ghostty among supported terminals.
+- **Shellcheck**: required for the modified bash script (per global `CLAUDE.md`).
+
+## Progress Tracking
+- Mark completed items with `[x]` immediately when done.
+- Add newly discovered tasks with ➕ prefix.
+- Document issues/blockers with ⚠️ prefix.
+- Update plan if implementation deviates from original scope.
+
+## Solution Overview
+- For each of the three scripts, insert a **ghostty block** after the existing wezterm block and before the final "no overlay terminal available" error.
+- The ghostty block:
+  1. Detects `TERM_PROGRAM == "ghostty"` and presence of `osascript`.
+  2. Creates a sentinel file path (shell) or tempfile (Python).
+  3. Writes a launcher shell script that runs the real command and touches the sentinel on exit (same pattern as kitty/wezterm blocks).
+  4. Invokes `osascript` with an AppleScript heredoc that calls `tell application "Ghostty"` to split the focused terminal downward, runs the launcher, zooms the new split, and returns the new terminal id.
+  5. Polls for the sentinel, then calls another `osascript` to close the new terminal (dismisses Ghostty's default "press any key to close" prompt).
+- All user-facing error messages updated: `"...requires tmux, kitty, wezterm, or ghostty"`.
+- Docstring/comment updates to list ghostty as a supported terminal.
+
+## Technical Details
+
+### AppleScript for launching (bash variant)
+```applescript
+on run argv
+    set launchScript to item 1 of argv
+    tell application "Ghostty"
+        set cfg to new surface configuration
+        set command of cfg to launchScript
+        set wait after command of cfg to false
+        set ft to focused terminal of selected tab of front window
+        set newTerm to split ft direction down with configuration cfg
+        perform action "toggle_split_zoom" on newTerm
+        return id of newTerm
+    end tell
+end run
+```
+
+### AppleScript for closing
+```applescript
+on run argv
+    tell application "Ghostty" to close terminal id (item 1 of argv)
+end run
+```
+
+### Python invocation pattern
+For the two `.py` scripts, mirror the bash heredoc pattern `osascript - "$LAUNCH_SCRIPT" <<'APPLESCRIPT' ... APPLESCRIPT`. In Python: argv[1] is `-` (tells osascript to read the script from stdin), argv[2] onward become the AppleScript's `argv`. Pass the AppleScript body via `input=` (stdin).
+
+Concrete snippet (launch):
+```python
+APPLESCRIPT = """on run argv
+    set launchScript to item 1 of argv
+    tell application "Ghostty"
+        set cfg to new surface configuration
+        set command of cfg to launchScript
+        set wait after command of cfg to false
+        set ft to focused terminal of selected tab of front window
+        set newTerm to split ft direction down with configuration cfg
+        perform action "toggle_split_zoom" on newTerm
+        return id of newTerm
+    end tell
+end run
+"""
+result = subprocess.run(
+    ["osascript", "-", str(launch_script_path)],
+    input=APPLESCRIPT, text=True, capture_output=True,
+)
+if result.returncode != 0:
+    # cleanup + return 1
+    ...
+ghostty_term_id = result.stdout.strip()
+```
+
+Close call (after sentinel):
+```python
+CLOSE_APPLESCRIPT = """on run argv
+    tell application "Ghostty" to close terminal id (item 1 of argv)
+end run
+"""
+subprocess.run(
+    ["osascript", "-", ghostty_term_id],
+    input=CLOSE_APPLESCRIPT, text=True, capture_output=True,
+)
+```
+
+### Block position (bash script)
+After the wezterm block (ends around line 79), before the final error (line 81). In Python scripts: after the wezterm branch, before `return 1`.
+
+### Env propagation note (relevant only if editor env goes missing)
+The revdiff reference prepends `/usr/bin/env EDITOR=... VISUAL=...` to the launcher command to survive Ghostty's `wait after command` re-exec shell. The current `plan-annotate.py` and `git-review.py` already resolve `$EDITOR` to an absolute path before passing it into the wrapper, so the env-prefix workaround is not needed here. Keep this in mind during manual verification — if `$EDITOR` fails to launch inside Ghostty, revisit.
+
+## What Goes Where
+- **Implementation Steps**: code edits to 3 scripts, docstring/comment updates, docs/README updates, plugin version bumps, shellcheck on bash.
+- **Post-Completion**: manual verification in a real Ghostty window (macOS only).
+
+## Implementation Steps
+
+### Task 1: Add ghostty block to launch-plan-review.sh
+
+**Files:**
+- Modify: `plugins/planning/scripts/launch-plan-review.sh`
+
+- [ ] Insert ghostty block after the wezterm block (after line 79), before the final error message.
+- [ ] Gate on `[ "${TERM_PROGRAM:-}" = "ghostty" ] && [ -z "${CMUX_SURFACE_ID:-}" ] && command -v osascript >/dev/null 2>&1` — cmux-guard prevents misrouting when cmux sets `TERM_PROGRAM=ghostty`.
+- [ ] Create sentinel file via `mktemp /tmp/plan-review-done-XXXXXX` and immediately `rm -f` (matches existing pattern).
+- [ ] Create launcher script via `mktemp` containing `#!/bin/sh` + `$REVDIFF_CMD; touch '$SENTINEL'`, `chmod +x`.
+- [ ] Update trap to clean up launcher script (`trap 'rm -f "$OUTPUT_FILE" "$SENTINEL" "$LAUNCH_SCRIPT"' EXIT`).
+- [ ] Add `osascript` call with split-down + toggle_split_zoom AppleScript, capturing new terminal id.
+- [ ] Poll `while [ ! -f "$SENTINEL" ]; do sleep 0.3; done`.
+- [ ] Add close AppleScript to dismiss "press any key" prompt.
+- [ ] `cat "$OUTPUT_FILE"` then `exit 0`.
+- [ ] Update final error message to: `"error: no overlay terminal available (requires tmux, kitty, wezterm, or ghostty)"`.
+- [ ] Run `shellcheck plugins/planning/scripts/launch-plan-review.sh` and fix any warnings.
+- [ ] Manual verify: launch `bash plugins/planning/scripts/launch-plan-review.sh <some-plan.md>` inside a Ghostty window — split pane opens, revdiff loads, exits cleanly, annotations captured.
+
+### Task 2: Add ghostty branch to plan-annotate.py open_editor
+
+**Files:**
+- Modify: `plugins/planning/scripts/plan-annotate.py`
+
+- [ ] Add ghostty branch inside `open_editor()` after the wezterm branch, before `return 1`.
+- [ ] Gate on `os.environ.get("TERM_PROGRAM") == "ghostty" and not os.environ.get("CMUX_SURFACE_ID") and shutil.which("osascript")` — cmux-guard prevents misrouting.
+- [ ] Create sentinel via `tempfile.mkstemp(prefix="plan-done-")` then unlink (existing pattern).
+- [ ] Build wrapper string: `f'{editor_cmd} {shlex.quote(str(filepath))}; touch {shlex.quote(str(sentinel))}'`.
+- [ ] Write wrapper to a temp launcher script via `tempfile.NamedTemporaryFile(mode="w", suffix=".sh", delete=False)` with `#!/bin/sh\n{wrapper}\n`, `chmod 0o755`.
+- [ ] Call `subprocess.run(["osascript", "-", launch_script_path], input=APPLESCRIPT, text=True, capture_output=True)` with the split+zoom AppleScript; read `result.stdout.strip()` as `ghostty_term_id`.
+- [ ] If osascript returns non-zero, unlink launcher + sentinel and `return 1`.
+- [ ] Poll sentinel with `time.sleep(0.3)` loop.
+- [ ] Call close AppleScript via `subprocess.run(["osascript", "-", ghostty_term_id], input=CLOSE_APPLESCRIPT, text=True, capture_output=True)`.
+- [ ] Unlink sentinel and launcher script, `return 0`.
+- [ ] Update top-of-file docstring: `requirements` list (line 29), `limitations` list (line 38), `terminal priority` line (line 35) to include ghostty.
+- [ ] Run `python3 plugins/planning/scripts/plan-annotate.py --test` to confirm embedded tests still pass (they do not exercise `open_editor`, so no changes expected).
+- [ ] Manual verify: invoke in file mode from Ghostty: `python3 plugins/planning/scripts/plan-annotate.py <some-plan.md>` — editor opens in split pane, edits produce diff on stdout.
+
+### Task 3: Add ghostty branch to git-review.py open_editor
+
+**Files:**
+- Modify: `plugins/review/skills/git-review/scripts/git-review.py`
+
+- [ ] Add ghostty branch inside `open_editor()` after the wezterm branch, before `return 1` (around line 312).
+- [ ] Mirror the Task 2 implementation — same cmux-guarded gate, launcher file, osascript pattern.
+- [ ] Use prefix `"review-done-"` for sentinel to match existing git-review.py naming (NOT `plan-done-` from Task 2).
+- [ ] Set AppleScript title/context to match — no title is shown for Ghostty splits, so no title parameter needed.
+- [ ] Update the function docstring (line 258): `tries tmux first (if $TMUX is set), then kitty, then wezterm, then ghostty.`.
+- [ ] Update the error message in `run_review` (line 373): `"error: no overlay terminal available (requires tmux, kitty, wezterm, or ghostty)"`.
+- [ ] Run any existing tests: there are no `--test` flag tests in git-review.py beyond `run_tests()` — confirm by inspection.
+- [ ] Manual verify: inside a git repo with changes, launch `/review:git-review` from Ghostty; editor opens in split pane, annotations diff is printed on close.
+
+### Task 4: Update user-facing documentation
+
+**Files:**
+- Modify: `README.md`
+- Modify: `plugins/planning/references/usage.md`
+- Modify: `plugins/planning/commands/make.md` (if it mentions terminal requirements)
+- Modify: `plugins/planning/scripts/plan-review-hook.py` (docstring mentions terminals)
+- Modify: `plugins/review/skills/git-review/SKILL.md` (if it mentions terminal requirements)
+
+- [ ] Run a broader grep to catch all phrasings (comma-separated, slash-separated, "or"): `grep -rEn "tmux[, /]|kitty[, /]|wezterm[, /]" plugins/ README.md` — update each hit to include ghostty.
+- [ ] Explicit docstring surfaces to update (line numbers may shift as Tasks 2/3 land; reference by section):
+  - `plan-annotate.py` module docstring: the `(tmux or kitty)` parenthetical in the first paragraph, the `terminal priority:` arrow list (`tmux display-popup → kitty overlay → wezterm split-pane → ghostty split → error`), the `requirements` list, and the `limitations` list (`does not work in plain terminals`).
+  - `git-review.py` module docstring: the `tmux/kitty/wezterm overlay` slash-separated form.
+  - `plan-review-hook.py` docstring `requirements` line: `tmux, kitty, wezterm, or ghostty terminal`.
+- [ ] In `README.md`, find the planning and review plugin descriptions; update terminal requirement phrasing.
+- [ ] Ensure wording is consistent across all files (use the same canonical phrase: `tmux, kitty, wezterm, or ghostty`).
+- [ ] Add a brief one-line note in the appropriate reference/README that Ghostty requires 1.3.0+ on macOS. Place it where other terminal-specific caveats (e.g., kitty `allow_remote_control`) already live.
+- [ ] Final verification grep: `grep -rEn "tmux[, /]|kitty[, /]|wezterm[, /]" plugins/ README.md` should show ghostty included in every user-facing hit (vendored files, completed plans, and git history references are excluded).
+
+### Task 5: Bump plugin versions
+
+**Files:**
+- Modify: `plugins/planning/.claude-plugin/plugin.json`
+- Modify: `plugins/review/.claude-plugin/plugin.json`
+
+- [ ] Bump `plugins/planning/.claude-plugin/plugin.json` version `3.4.0` → `3.5.0` (minor: new terminal support = new feature per CLAUDE.md versioning guidance).
+- [ ] Bump `plugins/review/.claude-plugin/plugin.json` version `2.2.1` → `2.3.0` (same reasoning).
+- [ ] Do NOT change marketplace.json (no structural changes).
+
+### Task 6: Verify acceptance criteria
+- [ ] All three scripts now detect Ghostty and open a split pane instead of erroring out.
+- [ ] Error message in all three scripts lists `ghostty` alongside tmux/kitty/wezterm.
+- [ ] Docstrings, references, and README are consistent and mention ghostty.
+- [ ] `shellcheck plugins/planning/scripts/launch-plan-review.sh` passes with no warnings.
+- [ ] `python3 plugins/planning/scripts/plan-annotate.py --test` still passes.
+- [ ] Grep-confirm there are no remaining "tmux, kitty, or wezterm" phrases that missed the update: `grep -rn "tmux, kitty" .` (excluding vendored files and completed plans).
+- [ ] Plugin versions bumped.
+
+### Task 7: [Final] Move plan to completed
+- [ ] `mkdir -p docs/plans/completed`
+- [ ] Move this plan file to `docs/plans/completed/`.
+
+## Post-Completion
+*Items requiring manual intervention outside this session.*
+
+**Manual verification** (must be run from a Ghostty 1.3.0+ window on macOS):
+- `/planning:make` → choose interactive review → confirm revdiff opens as a Ghostty split pane below, annotations loop works, split closes cleanly on quit.
+- Trigger the `plan-annotate.py` fallback path (temporarily rename `revdiff` binary or unset from PATH) → confirm editor opens in Ghostty split pane, diff is returned on close.
+- `/review:git-review` inside a repo with uncommitted changes → confirm `$EDITOR` opens in Ghostty split pane, diff annotations are captured.
+- Negative: run each from plain Terminal.app (no TMUX, no Ghostty) → confirm the updated error message is shown with `ghostty` listed as a supported terminal.
+
+**Release / marketplace**:
+- Tag a release once changes land (user's standard release flow — out of scope for this plan).
+- No `marketplace.json` update needed; plugin versions within their own `plugin.json` files handle discovery.

--- a/docs/plans/20260418-ghostty-overlay-support.md
+++ b/docs/plans/20260418-ghostty-overlay-support.md
@@ -151,19 +151,19 @@ The revdiff reference prepends `/usr/bin/env EDITOR=... VISUAL=...` to the launc
 **Files:**
 - Modify: `plugins/planning/scripts/plan-annotate.py`
 
-- [ ] Add ghostty branch inside `open_editor()` after the wezterm branch, before `return 1`.
-- [ ] Gate on `os.environ.get("TERM_PROGRAM") == "ghostty" and not os.environ.get("CMUX_SURFACE_ID") and shutil.which("osascript")` — cmux-guard prevents misrouting.
-- [ ] Create sentinel via `tempfile.mkstemp(prefix="plan-done-")` then unlink (existing pattern).
-- [ ] Build wrapper string: `f'{editor_cmd} {shlex.quote(str(filepath))}; touch {shlex.quote(str(sentinel))}'`.
-- [ ] Write wrapper to a temp launcher script via `tempfile.NamedTemporaryFile(mode="w", suffix=".sh", delete=False)` with `#!/bin/sh\n{wrapper}\n`, `chmod 0o755`.
-- [ ] Call `subprocess.run(["osascript", "-", launch_script_path], input=APPLESCRIPT, text=True, capture_output=True)` with the split+zoom AppleScript; read `result.stdout.strip()` as `ghostty_term_id`.
-- [ ] If osascript returns non-zero, unlink launcher + sentinel and `return 1`.
-- [ ] Poll sentinel with `time.sleep(0.3)` loop.
-- [ ] Call close AppleScript via `subprocess.run(["osascript", "-", ghostty_term_id], input=CLOSE_APPLESCRIPT, text=True, capture_output=True)`.
-- [ ] Unlink sentinel and launcher script, `return 0`.
-- [ ] Update top-of-file docstring: `requirements` list (line 29), `limitations` list (line 38), `terminal priority` line (line 35) to include ghostty.
-- [ ] Run `python3 plugins/planning/scripts/plan-annotate.py --test` to confirm embedded tests still pass (they do not exercise `open_editor`, so no changes expected).
-- [ ] Manual verify: invoke in file mode from Ghostty: `python3 plugins/planning/scripts/plan-annotate.py <some-plan.md>` — editor opens in split pane, edits produce diff on stdout.
+- [x] Add ghostty branch inside `open_editor()` after the wezterm branch, before `return 1`.
+- [x] Gate on `os.environ.get("TERM_PROGRAM") == "ghostty" and not os.environ.get("CMUX_SURFACE_ID") and shutil.which("osascript")` — cmux-guard prevents misrouting.
+- [x] Create sentinel via `tempfile.mkstemp(prefix="plan-done-")` then unlink (existing pattern).
+- [x] Build wrapper string: `f'{editor_cmd} {shlex.quote(str(filepath))}; touch {shlex.quote(str(sentinel))}'`.
+- [x] Write wrapper to a temp launcher script via `tempfile.NamedTemporaryFile(mode="w", suffix=".sh", delete=False)` with `#!/bin/sh\n{wrapper}\n`, `chmod 0o755`.
+- [x] Call `subprocess.run(["osascript", "-", launch_script_path], input=APPLESCRIPT, text=True, capture_output=True)` with the split+zoom AppleScript; read `result.stdout.strip()` as `ghostty_term_id`.
+- [x] If osascript returns non-zero, unlink launcher + sentinel and `return 1`.
+- [x] Poll sentinel with `time.sleep(0.3)` loop.
+- [x] Call close AppleScript via `subprocess.run(["osascript", "-", ghostty_term_id], input=CLOSE_APPLESCRIPT, text=True, capture_output=True)`.
+- [x] Unlink sentinel and launcher script, `return 0`.
+- [x] Update top-of-file docstring: `requirements` list (line 29), `limitations` list (line 38), `terminal priority` line (line 35) to include ghostty.
+- [x] Run `python3 plugins/planning/scripts/plan-annotate.py --test` to confirm embedded tests still pass (they do not exercise `open_editor`, so no changes expected).
+- [x] manual verify (skipped - not automatable): invoke in file mode from Ghostty: `python3 plugins/planning/scripts/plan-annotate.py <some-plan.md>` — editor opens in split pane, edits produce diff on stdout.
 
 ### Task 3: Add ghostty branch to git-review.py open_editor
 

--- a/docs/plans/20260418-ghostty-overlay-support.md
+++ b/docs/plans/20260418-ghostty-overlay-support.md
@@ -209,13 +209,13 @@ The revdiff reference prepends `/usr/bin/env EDITOR=... VISUAL=...` to the launc
 - [x] Do NOT change marketplace.json (no structural changes).
 
 ### Task 6: Verify acceptance criteria
-- [ ] All three scripts now detect Ghostty and open a split pane instead of erroring out.
-- [ ] Error message in all three scripts lists `ghostty` alongside tmux/kitty/wezterm.
-- [ ] Docstrings, references, and README are consistent and mention ghostty.
-- [ ] `shellcheck plugins/planning/scripts/launch-plan-review.sh` passes with no warnings.
-- [ ] `python3 plugins/planning/scripts/plan-annotate.py --test` still passes.
-- [ ] Grep-confirm there are no remaining "tmux, kitty, or wezterm" phrases that missed the update: `grep -rn "tmux, kitty" .` (excluding vendored files and completed plans).
-- [ ] Plugin versions bumped.
+- [x] All three scripts now detect Ghostty and open a split pane instead of erroring out.
+- [x] Error message in all three scripts lists `ghostty` alongside tmux/kitty/wezterm.
+- [x] Docstrings, references, and README are consistent and mention ghostty.
+- [x] `shellcheck plugins/planning/scripts/launch-plan-review.sh` passes with no warnings.
+- [x] `python3 plugins/planning/scripts/plan-annotate.py --test` still passes.
+- [x] Grep-confirm there are no remaining "tmux, kitty, or wezterm" phrases that missed the update: `grep -rn "tmux, kitty" .` (excluding vendored files and completed plans).
+- [x] Plugin versions bumped.
 
 ### Task 7: [Final] Move plan to completed
 - [ ] `mkdir -p docs/plans/completed`

--- a/docs/plans/20260418-ghostty-overlay-support.md
+++ b/docs/plans/20260418-ghostty-overlay-support.md
@@ -133,18 +133,18 @@ The revdiff reference prepends `/usr/bin/env EDITOR=... VISUAL=...` to the launc
 **Files:**
 - Modify: `plugins/planning/scripts/launch-plan-review.sh`
 
-- [ ] Insert ghostty block after the wezterm block (after line 79), before the final error message.
-- [ ] Gate on `[ "${TERM_PROGRAM:-}" = "ghostty" ] && [ -z "${CMUX_SURFACE_ID:-}" ] && command -v osascript >/dev/null 2>&1` — cmux-guard prevents misrouting when cmux sets `TERM_PROGRAM=ghostty`.
-- [ ] Create sentinel file via `mktemp /tmp/plan-review-done-XXXXXX` and immediately `rm -f` (matches existing pattern).
-- [ ] Create launcher script via `mktemp` containing `#!/bin/sh` + `$REVDIFF_CMD; touch '$SENTINEL'`, `chmod +x`.
-- [ ] Update trap to clean up launcher script (`trap 'rm -f "$OUTPUT_FILE" "$SENTINEL" "$LAUNCH_SCRIPT"' EXIT`).
-- [ ] Add `osascript` call with split-down + toggle_split_zoom AppleScript, capturing new terminal id.
-- [ ] Poll `while [ ! -f "$SENTINEL" ]; do sleep 0.3; done`.
-- [ ] Add close AppleScript to dismiss "press any key" prompt.
-- [ ] `cat "$OUTPUT_FILE"` then `exit 0`.
-- [ ] Update final error message to: `"error: no overlay terminal available (requires tmux, kitty, wezterm, or ghostty)"`.
-- [ ] Run `shellcheck plugins/planning/scripts/launch-plan-review.sh` and fix any warnings.
-- [ ] Manual verify: launch `bash plugins/planning/scripts/launch-plan-review.sh <some-plan.md>` inside a Ghostty window — split pane opens, revdiff loads, exits cleanly, annotations captured.
+- [x] Insert ghostty block after the wezterm block (after line 79), before the final error message.
+- [x] Gate on `[ "${TERM_PROGRAM:-}" = "ghostty" ] && [ -z "${CMUX_SURFACE_ID:-}" ] && command -v osascript >/dev/null 2>&1` — cmux-guard prevents misrouting when cmux sets `TERM_PROGRAM=ghostty`.
+- [x] Create sentinel file via `mktemp /tmp/plan-review-done-XXXXXX` and immediately `rm -f` (matches existing pattern).
+- [x] Create launcher script via `mktemp` containing `#!/bin/sh` + `$REVDIFF_CMD; touch '$SENTINEL'`, `chmod +x`.
+- [x] Update trap to clean up launcher script (`trap 'rm -f "$OUTPUT_FILE" "$SENTINEL" "$LAUNCH_SCRIPT"' EXIT`).
+- [x] Add `osascript` call with split-down + toggle_split_zoom AppleScript, capturing new terminal id.
+- [x] Poll `while [ ! -f "$SENTINEL" ]; do sleep 0.3; done`.
+- [x] Add close AppleScript to dismiss "press any key" prompt.
+- [x] `cat "$OUTPUT_FILE"` then `exit 0`.
+- [x] Update final error message to: `"error: no overlay terminal available (requires tmux, kitty, wezterm, or ghostty)"`.
+- [x] Run `shellcheck plugins/planning/scripts/launch-plan-review.sh` and fix any warnings.
+- [x] manual verify (skipped - not automatable): launch `bash plugins/planning/scripts/launch-plan-review.sh <some-plan.md>` inside a Ghostty window — split pane opens, revdiff loads, exits cleanly, annotations captured.
 
 ### Task 2: Add ghostty branch to plan-annotate.py open_editor
 

--- a/docs/plans/completed/20260418-ghostty-overlay-support.md
+++ b/docs/plans/completed/20260418-ghostty-overlay-support.md
@@ -218,8 +218,8 @@ The revdiff reference prepends `/usr/bin/env EDITOR=... VISUAL=...` to the launc
 - [x] Plugin versions bumped.
 
 ### Task 7: [Final] Move plan to completed
-- [ ] `mkdir -p docs/plans/completed`
-- [ ] Move this plan file to `docs/plans/completed/`.
+- [x] `mkdir -p docs/plans/completed`
+- [x] Move this plan file to `docs/plans/completed/`.
 
 ## Post-Completion
 *Items requiring manual intervention outside this session.*

--- a/plugins/planning/.claude-plugin/plugin.json
+++ b/plugins/planning/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "planning",
   "description": "Structured implementation planning, interactive annotation review, and autonomous plan execution",
-  "version": "3.4.0",
+  "version": "3.5.0",
   "author": {
     "name": "Umputun"
   },

--- a/plugins/planning/scripts/launch-plan-review.sh
+++ b/plugins/planning/scripts/launch-plan-review.sh
@@ -145,5 +145,8 @@ APPLESCRIPT
     exit 0
 fi
 
+# exit 127 ("command not found" convention) signals no overlay terminal was
+# available, so callers can fall back to a different review UI. All other
+# exit 1 paths above indicate an overlay WAS attempted but failed.
 echo "error: no overlay terminal available (requires tmux, kitty, wezterm, or ghostty)" >&2
-exit 1
+exit 127

--- a/plugins/planning/scripts/launch-plan-review.sh
+++ b/plugins/planning/scripts/launch-plan-review.sh
@@ -86,6 +86,11 @@ if [ "${TERM_PROGRAM:-}" = "ghostty" ] && [ -z "${CMUX_SURFACE_ID:-}" ] && comma
     rm -f "$SENTINEL"
 
     LAUNCH_SCRIPT=$(mktemp /tmp/plan-review-launch-XXXXXX)
+    # extend the EXIT trap so a SIGINT during polling or any unexpected
+    # failure (e.g. chmod failing under set -e) doesn't leak temp files.
+    # explicit rm -f calls below remain as the happy/error-path cleanup
+    # and are idempotent with this trap.
+    trap 'rm -f "$OUTPUT_FILE" "$SENTINEL" "$LAUNCH_SCRIPT"' EXIT
     cat > "$LAUNCH_SCRIPT" <<LAUNCHER
 #!/bin/sh
 $REVDIFF_CMD; touch '$SENTINEL'

--- a/plugins/planning/scripts/launch-plan-review.sh
+++ b/plugins/planning/scripts/launch-plan-review.sh
@@ -97,12 +97,14 @@ $REVDIFF_CMD; touch '$SENTINEL'
 LAUNCHER
     chmod +x "$LAUNCH_SCRIPT"
 
-    if ! GHOSTTY_TERM_ID=$(osascript - "$LAUNCH_SCRIPT" <<'APPLESCRIPT'
+    if ! GHOSTTY_TERM_ID=$(osascript - "$LAUNCH_SCRIPT" "$PWD" <<'APPLESCRIPT'
 on run argv
     set launchScript to item 1 of argv
+    set cwd to item 2 of argv
     tell application "Ghostty"
         set cfg to new surface configuration
         set command of cfg to launchScript
+        set initial working directory of cfg to cwd
         set wait after command of cfg to false
         set ft to focused terminal of selected tab of front window
         set newTerm to split ft direction down with configuration cfg

--- a/plugins/planning/scripts/launch-plan-review.sh
+++ b/plugins/planning/scripts/launch-plan-review.sh
@@ -124,6 +124,13 @@ APPLESCRIPT
         exit 1
     fi
 
+    # now that we have a valid term id, extend the trap to also close the
+    # split if the parent shell is interrupted (SIGINT/SIGTERM) before the
+    # explicit close AppleScript runs. `|| true` keeps the trap clean when
+    # the user already closed the pane manually.
+    # shellcheck disable=SC2064  # expand GHOSTTY_TERM_ID at trap-set time
+    trap "rm -f \"\$OUTPUT_FILE\" \"\$SENTINEL\" \"\$LAUNCH_SCRIPT\"; osascript -e 'tell application \"Ghostty\" to close terminal id $GHOSTTY_TERM_ID' >/dev/null 2>&1 || true" EXIT
+
     while [ ! -f "$SENTINEL" ]; do
         sleep 0.3
     done

--- a/plugins/planning/scripts/launch-plan-review.sh
+++ b/plugins/planning/scripts/launch-plan-review.sh
@@ -86,7 +86,6 @@ if [ "${TERM_PROGRAM:-}" = "ghostty" ] && [ -z "${CMUX_SURFACE_ID:-}" ] && comma
     rm -f "$SENTINEL"
 
     LAUNCH_SCRIPT=$(mktemp /tmp/plan-review-launch-XXXXXX)
-    trap 'rm -f "$OUTPUT_FILE" "$SENTINEL" "$LAUNCH_SCRIPT"' EXIT
     cat > "$LAUNCH_SCRIPT" <<LAUNCHER
 #!/bin/sh
 $REVDIFF_CMD; touch '$SENTINEL'
@@ -108,6 +107,12 @@ on run argv
 end run
 APPLESCRIPT
     ); then
+        rm -f "$SENTINEL" "$LAUNCH_SCRIPT"
+        exit 1
+    fi
+    # AppleScript can exit 0 with empty stdout on edge cases (e.g. no front
+    # window). Bail out rather than polling forever / running close on "".
+    if [ -z "$GHOSTTY_TERM_ID" ]; then
         rm -f "$SENTINEL" "$LAUNCH_SCRIPT"
         exit 1
     fi

--- a/plugins/planning/scripts/launch-plan-review.sh
+++ b/plugins/planning/scripts/launch-plan-review.sh
@@ -78,5 +78,53 @@ if [ -n "${WEZTERM_PANE:-}" ] && command -v wezterm >/dev/null 2>&1; then
     exit 0
 fi
 
-echo "error: no overlay terminal available (requires tmux, kitty, or wezterm)" >&2
+# ghostty: split pane via AppleScript (macOS only, requires Ghostty 1.3.0+).
+# cmux sets TERM_PROGRAM=ghostty too; guard on CMUX_SURFACE_ID to avoid
+# misrouting a cmux session into a real-Ghostty AppleScript split.
+if [ "${TERM_PROGRAM:-}" = "ghostty" ] && [ -z "${CMUX_SURFACE_ID:-}" ] && command -v osascript >/dev/null 2>&1; then
+    SENTINEL=$(mktemp /tmp/plan-review-done-XXXXXX)
+    rm -f "$SENTINEL"
+
+    LAUNCH_SCRIPT=$(mktemp /tmp/plan-review-launch-XXXXXX)
+    trap 'rm -f "$OUTPUT_FILE" "$SENTINEL" "$LAUNCH_SCRIPT"' EXIT
+    cat > "$LAUNCH_SCRIPT" <<LAUNCHER
+#!/bin/sh
+$REVDIFF_CMD; touch '$SENTINEL'
+LAUNCHER
+    chmod +x "$LAUNCH_SCRIPT"
+
+    if ! GHOSTTY_TERM_ID=$(osascript - "$LAUNCH_SCRIPT" <<'APPLESCRIPT'
+on run argv
+    set launchScript to item 1 of argv
+    tell application "Ghostty"
+        set cfg to new surface configuration
+        set command of cfg to launchScript
+        set wait after command of cfg to false
+        set ft to focused terminal of selected tab of front window
+        set newTerm to split ft direction down with configuration cfg
+        perform action "toggle_split_zoom" on newTerm
+        return id of newTerm
+    end tell
+end run
+APPLESCRIPT
+    ); then
+        rm -f "$SENTINEL" "$LAUNCH_SCRIPT"
+        exit 1
+    fi
+
+    while [ ! -f "$SENTINEL" ]; do
+        sleep 0.3
+    done
+    # dismiss Ghostty's default "press any key to close" prompt
+    osascript - "$GHOSTTY_TERM_ID" <<'APPLESCRIPT' 2>/dev/null
+on run argv
+    tell application "Ghostty" to close terminal id (item 1 of argv)
+end run
+APPLESCRIPT
+    rm -f "$SENTINEL" "$LAUNCH_SCRIPT"
+    cat "$OUTPUT_FILE"
+    exit 0
+fi
+
+echo "error: no overlay terminal available (requires tmux, kitty, wezterm, or ghostty)" >&2
 exit 1

--- a/plugins/planning/scripts/plan-annotate.py
+++ b/plugins/planning/scripts/plan-annotate.py
@@ -111,7 +111,9 @@ def open_editor(filepath: Path, target_window: bool = True) -> int:
     # resolve the first token of $EDITOR to an absolute path so that
     # sh -c (used by kitty/wezterm overlays) can find the binary even
     # when /opt/homebrew/bin or similar dirs are not in sh's default PATH.
-    editor_parts = shlex.split(editor)
+    # fall back to 'micro' if $EDITOR is unset, empty, or whitespace-only —
+    # shlex.split returns [] for those, which would crash on indexing.
+    editor_parts = shlex.split(editor) or ["micro"]
     resolved = shutil.which(editor_parts[0])
     if resolved:
         editor_parts[0] = resolved
@@ -207,37 +209,38 @@ def open_editor(filepath: Path, target_window: bool = True) -> int:
     end tell
 end run
 """
-        result = subprocess.run(
-            ["osascript", "-", str(launch_script_path), str(Path.cwd())],
-            input=applescript, text=True, capture_output=True,
-        )
-        if result.returncode != 0:
-            launch_script_path.unlink(missing_ok=True)
-            sentinel.unlink(missing_ok=True)
-            return 1
-        ghostty_term_id = result.stdout.strip()
-        if not ghostty_term_id:
-            # AppleScript succeeded but returned nothing — bail out rather
-            # than blocking forever or running the close script on empty id.
-            launch_script_path.unlink(missing_ok=True)
-            sentinel.unlink(missing_ok=True)
-            return 1
-
-        while not sentinel.exists():
-            time.sleep(0.3)
-
-        # dismiss Ghostty's default "press any key to close" prompt
         close_applescript = """on run argv
     tell application "Ghostty" to close terminal id (item 1 of argv)
 end run
 """
-        subprocess.run(
-            ["osascript", "-", ghostty_term_id],
-            input=close_applescript, text=True, capture_output=True,
-        )
-        sentinel.unlink(missing_ok=True)
-        launch_script_path.unlink(missing_ok=True)
-        return 0
+        ghostty_term_id = ""
+        try:
+            result = subprocess.run(
+                ["osascript", "-", str(launch_script_path), str(Path.cwd())],
+                input=applescript, text=True, capture_output=True,
+            )
+            if result.returncode != 0:
+                return 1
+            ghostty_term_id = result.stdout.strip()
+            if not ghostty_term_id:
+                # AppleScript succeeded but returned nothing — bail out rather
+                # than blocking forever or running the close script on empty id.
+                return 1
+
+            while not sentinel.exists():
+                time.sleep(0.3)
+            return 0
+        finally:
+            # best-effort cleanup: ensure sentinel, launcher script, and the
+            # Ghostty split pane don't leak on Ctrl-C or any other exception.
+            if ghostty_term_id:
+                subprocess.run(
+                    ["osascript", "-", ghostty_term_id],
+                    input=close_applescript, text=True, capture_output=True,
+                    check=False,
+                )
+            sentinel.unlink(missing_ok=True)
+            launch_script_path.unlink(missing_ok=True)
 
     return 1
 

--- a/plugins/planning/scripts/plan-annotate.py
+++ b/plugins/planning/scripts/plan-annotate.py
@@ -4,7 +4,7 @@
 interactive plan review hook that lets you annotate Claude's plans directly
 in your editor before approving them. when Claude calls ExitPlanMode, this
 hook intercepts the call, opens the plan in $EDITOR via a terminal overlay
-(tmux or kitty), and waits for you to review/edit. if you make changes,
+(tmux, kitty, wezterm, or ghostty), and waits for you to review/edit. if you make changes,
 the hook computes a unified diff and sends it back to Claude as a denial
 reason, forcing Claude to revise the plan based on your annotations. if
 you make no changes, the normal approval dialog appears.
@@ -26,16 +26,17 @@ returns PreToolUse hook JSON response with permissionDecision:
   - "deny" → changes detected, unified diff sent as denial reason
 
 requirements:
-  - tmux, kitty, or wezterm terminal (tmux tried first, then kitty, then wezterm)
+  - tmux, kitty, wezterm, or ghostty terminal (tmux tried first, then kitty, then wezterm, then ghostty)
   - $EDITOR set (defaults to micro)
   - kitty users: kitty.conf must have allow_remote_control and listen_on configured:
       allow_remote_control yes
       listen_on unix:/tmp/kitty-$KITTY_PID
+  - ghostty users: requires Ghostty 1.3.0+ on macOS (uses AppleScript)
 
-terminal priority: tmux display-popup → kitty overlay → wezterm split-pane → error
+terminal priority: tmux display-popup → kitty overlay → wezterm split-pane → ghostty split → error
 
 limitations:
-  - requires tmux, kitty, or wezterm - without any, returns error (no annotation)
+  - requires tmux, kitty, wezterm, or ghostty - without any, returns error (no annotation)
   - does not work in plain terminals (iTerm2, Terminal.app, etc.)
   - kitty requires KITTY_LISTEN_ON env var (set by kitty when listen_on is configured)
   - the hook blocks until the editor closes; timeout should be set high
@@ -102,8 +103,8 @@ def get_diff(original: str, edited: str) -> str:
 
 
 def open_editor(filepath: Path, target_window: bool = True) -> int:
-    """open file in $EDITOR via tmux popup, kitty overlay, or wezterm split-pane, blocking until editor closes.
-    tries tmux first (if $TMUX is set), then kitty, then wezterm. returns non-zero if none is available.
+    """open file in $EDITOR via tmux popup, kitty overlay, wezterm split-pane, or ghostty split, blocking until editor closes.
+    tries tmux first (if $TMUX is set), then kitty, then wezterm, then ghostty. returns non-zero if none is available.
     when target_window is True (hook mode), targets the kitty window from KITTY_WINDOW_ID.
     when False (file mode), opens in the currently focused window."""
     editor = os.environ.get("EDITOR", "micro")
@@ -167,6 +168,67 @@ def open_editor(filepath: Path, target_window: bool = True) -> int:
         while not sentinel.exists():
             time.sleep(0.3)
         sentinel.unlink(missing_ok=True)
+        return 0
+
+    # ghostty: split pane via AppleScript (macOS only, requires Ghostty 1.3.0+).
+    # cmux sets TERM_PROGRAM=ghostty too; guard on CMUX_SURFACE_ID to avoid
+    # misrouting a cmux session into a real-Ghostty AppleScript split.
+    if (
+        os.environ.get("TERM_PROGRAM") == "ghostty"
+        and not os.environ.get("CMUX_SURFACE_ID")
+        and shutil.which("osascript")
+    ):
+        fd, sentinel_path = tempfile.mkstemp(prefix="plan-done-")
+        os.close(fd)
+        os.unlink(sentinel_path)
+        sentinel = Path(sentinel_path)
+        wrapper = f'{editor_cmd} {shlex.quote(str(filepath))}; touch {shlex.quote(str(sentinel))}'
+
+        launcher = tempfile.NamedTemporaryFile(
+            mode="w", suffix=".sh", prefix="plan-launch-", delete=False
+        )
+        launcher.write(f"#!/bin/sh\n{wrapper}\n")
+        launcher.close()
+        launch_script_path = Path(launcher.name)
+        os.chmod(launch_script_path, 0o755)
+
+        applescript = """on run argv
+    set launchScript to item 1 of argv
+    tell application "Ghostty"
+        set cfg to new surface configuration
+        set command of cfg to launchScript
+        set wait after command of cfg to false
+        set ft to focused terminal of selected tab of front window
+        set newTerm to split ft direction down with configuration cfg
+        perform action "toggle_split_zoom" on newTerm
+        return id of newTerm
+    end tell
+end run
+"""
+        result = subprocess.run(
+            ["osascript", "-", str(launch_script_path)],
+            input=applescript, text=True, capture_output=True,
+        )
+        if result.returncode != 0:
+            launch_script_path.unlink(missing_ok=True)
+            sentinel.unlink(missing_ok=True)
+            return 1
+        ghostty_term_id = result.stdout.strip()
+
+        while not sentinel.exists():
+            time.sleep(0.3)
+
+        # dismiss Ghostty's default "press any key to close" prompt
+        close_applescript = """on run argv
+    tell application "Ghostty" to close terminal id (item 1 of argv)
+end run
+"""
+        subprocess.run(
+            ["osascript", "-", ghostty_term_id],
+            input=close_applescript, text=True, capture_output=True,
+        )
+        sentinel.unlink(missing_ok=True)
+        launch_script_path.unlink(missing_ok=True)
         return 0
 
     return 1

--- a/plugins/planning/scripts/plan-annotate.py
+++ b/plugins/planning/scripts/plan-annotate.py
@@ -4,10 +4,10 @@
 interactive plan review hook that lets you annotate Claude's plans directly
 in your editor before approving them. when Claude calls ExitPlanMode, this
 hook intercepts the call, opens the plan in $EDITOR via a terminal overlay
-(tmux, kitty, wezterm, or ghostty), and waits for you to review/edit. if you make changes,
-the hook computes a unified diff and sends it back to Claude as a denial
-reason, forcing Claude to revise the plan based on your annotations. if
-you make no changes, the normal approval dialog appears.
+(tmux, kitty, wezterm, or ghostty), and waits for you to review/edit. if
+you make changes, the hook computes a unified diff and sends it back to
+Claude as a denial reason, forcing Claude to revise the plan based on your
+annotations. if you make no changes, the normal approval dialog appears.
 
 this creates a feedback loop: annotate → Claude revises → annotate again →
 until you're satisfied and close the editor without changes.
@@ -26,19 +26,20 @@ returns PreToolUse hook JSON response with permissionDecision:
   - "deny" → changes detected, unified diff sent as denial reason
 
 requirements:
-  - tmux, kitty, wezterm, or ghostty terminal (tmux tried first, then kitty, then wezterm, then ghostty)
+  - tmux, kitty, wezterm, or ghostty terminal (tried in that order)
   - $EDITOR set (defaults to micro)
-  - kitty users: kitty.conf must have allow_remote_control and listen_on configured:
+  - kitty users: kitty.conf must have allow_remote_control and listen_on:
       allow_remote_control yes
       listen_on unix:/tmp/kitty-$KITTY_PID
   - ghostty users: requires Ghostty 1.3.0+ on macOS (uses AppleScript)
 
-terminal priority: tmux display-popup → kitty overlay → wezterm split-pane → ghostty split → error
+terminal priority: tmux display-popup → kitty overlay →
+                   wezterm split-pane → ghostty split → error
 
 limitations:
-  - requires tmux, kitty, wezterm, or ghostty - without any, returns error (no annotation)
+  - requires one of the supported terminals; otherwise returns an error
   - does not work in plain terminals (iTerm2, Terminal.app, etc.)
-  - kitty requires KITTY_LISTEN_ON env var (set by kitty when listen_on is configured)
+  - kitty requires KITTY_LISTEN_ON env var (set when listen_on is on)
   - the hook blocks until the editor closes; timeout should be set high
   - plan content comes from Claude's ExitPlanMode call, not from the plan
     file on disk - if you edit the file on disk separately, those changes
@@ -103,10 +104,13 @@ def get_diff(original: str, edited: str) -> str:
 
 
 def open_editor(filepath: Path, target_window: bool = True) -> int:
-    """open file in $EDITOR via tmux popup, kitty overlay, wezterm split-pane, or ghostty split, blocking until editor closes.
-    tries tmux first (if $TMUX is set), then kitty, then wezterm, then ghostty. returns non-zero if none is available.
-    when target_window is True (hook mode), targets the kitty window from KITTY_WINDOW_ID.
-    when False (file mode), opens in the currently focused window."""
+    """open file in $EDITOR via tmux popup, kitty overlay, wezterm
+    split-pane, or ghostty split, blocking until editor closes. tries
+    tmux first (if $TMUX is set), then kitty, then wezterm, then
+    ghostty. returns non-zero if none is available. when target_window
+    is True (hook mode), targets the kitty window from
+    KITTY_WINDOW_ID. when False (file mode), opens in the currently
+    focused window."""
     editor = os.environ.get("EDITOR", "micro")
     # resolve the first token of $EDITOR to an absolute path so that
     # sh -c (used by kitty/wezterm overlays) can find the binary even

--- a/plugins/planning/scripts/plan-annotate.py
+++ b/plugins/planning/scripts/plan-annotate.py
@@ -194,9 +194,11 @@ def open_editor(filepath: Path, target_window: bool = True) -> int:
 
         applescript = """on run argv
     set launchScript to item 1 of argv
+    set cwd to item 2 of argv
     tell application "Ghostty"
         set cfg to new surface configuration
         set command of cfg to launchScript
+        set initial working directory of cfg to cwd
         set wait after command of cfg to false
         set ft to focused terminal of selected tab of front window
         set newTerm to split ft direction down with configuration cfg
@@ -206,7 +208,7 @@ def open_editor(filepath: Path, target_window: bool = True) -> int:
 end run
 """
         result = subprocess.run(
-            ["osascript", "-", str(launch_script_path)],
+            ["osascript", "-", str(launch_script_path), str(Path.cwd())],
             input=applescript, text=True, capture_output=True,
         )
         if result.returncode != 0:
@@ -214,6 +216,12 @@ end run
             sentinel.unlink(missing_ok=True)
             return 1
         ghostty_term_id = result.stdout.strip()
+        if not ghostty_term_id:
+            # AppleScript succeeded but returned nothing — bail out rather
+            # than blocking forever or running the close script on empty id.
+            launch_script_path.unlink(missing_ok=True)
+            sentinel.unlink(missing_ok=True)
+            return 1
 
         while not sentinel.exists():
             time.sleep(0.3)

--- a/plugins/planning/scripts/plan-annotate.py
+++ b/plugins/planning/scripts/plan-annotate.py
@@ -249,7 +249,7 @@ def run_file_mode(plan_file: Path) -> None:
 
     try:
         if open_editor(tmp_path, target_window=False) != 0:
-            print("error: no overlay terminal available (requires tmux, kitty, or wezterm)", file=sys.stderr)
+            print("error: no overlay terminal available (requires tmux, kitty, wezterm, or ghostty)", file=sys.stderr)
             sys.exit(1)
 
         edited_content = tmp_path.read_text()
@@ -275,7 +275,7 @@ def run_hook_mode() -> None:
 
     try:
         if open_editor(tmp_path) != 0:
-            print(make_response("ask", "no overlay terminal available (requires tmux, kitty, or wezterm), skipping plan annotation"))
+            print(make_response("ask", "no overlay terminal available (requires tmux, kitty, wezterm, or ghostty), skipping plan annotation"))
             return
 
         edited_content = tmp_path.read_text()

--- a/plugins/planning/scripts/plan-review-hook.py
+++ b/plugins/planning/scripts/plan-review-hook.py
@@ -55,7 +55,18 @@ def make_response(decision: str, reason: str = "") -> None:
 
 
 def try_revdiff(plan_content: str, plugin_root: str) -> str | None:
-    """try reviewing plan with revdiff. returns annotations or None if revdiff unavailable."""
+    """try reviewing plan with revdiff.
+
+    returns:
+        None: revdiff unavailable, launcher missing, or no overlay terminal
+              (exit 127) → caller should fall back to plan-annotate.py
+        "":   plan reviewed with no annotations → caller should respond "ask"
+        str:  user annotations → caller should respond "deny" with this text
+
+    on launcher/runtime failure (non-zero, non-127 exit) this function emits
+    an "ask" response via make_response() and exits the process directly —
+    a tool failure should NOT block ExitPlanMode as if the plan were wrong.
+    """
     if not shutil.which("revdiff"):
         return None
 
@@ -78,19 +89,22 @@ def try_revdiff(plan_content: str, plugin_root: str) -> str | None:
         )
         # distinguish launcher outcomes:
         #   exit 127     → no overlay terminal available; fall back to plan-annotate.py
-        #   other non-0 → overlay was attempted but launcher/revdiff failed; surface
-        #                 as a deny reason so the user sees the actual error instead
-        #                 of a silent second review UI popping up
+        #   other non-0 → overlay attempted but launcher/revdiff failed; surface
+        #                 as "ask" so the user sees the tool error without the plan
+        #                 being wrongly rejected as needing revision
         #   exit 0, ""   → user reviewed the plan and added no annotations (approve)
         #   exit 0, text → user added annotations (deny with feedback)
         if result.returncode == 127:
             return None
         if result.returncode != 0:
             stderr_text = (result.stderr or "").strip()[:500] or "no stderr output"
-            return (
-                f"revdiff review failed (exit {result.returncode}): {stderr_text}\n\n"
-                "revise the plan or try again."
+            make_response(
+                "ask",
+                f"revdiff review failed (exit {result.returncode}): {stderr_text}",
             )
+            # make_response only sys.exits on "deny"; exit explicitly so main()
+            # doesn't continue and misinterpret this as user feedback.
+            sys.exit(0)
         annotations = result.stdout.strip()
         if not annotations:
             return ""

--- a/plugins/planning/scripts/plan-review-hook.py
+++ b/plugins/planning/scripts/plan-review-hook.py
@@ -12,7 +12,7 @@ returns PreToolUse hook JSON response with permissionDecision:
 
 requirements:
   - revdiff (preferred) or $EDITOR (fallback)
-  - tmux, kitty, or wezterm terminal
+  - tmux, kitty, wezterm, or ghostty terminal
 """
 
 import json

--- a/plugins/planning/scripts/plan-review-hook.py
+++ b/plugins/planning/scripts/plan-review-hook.py
@@ -76,6 +76,13 @@ def try_revdiff(plan_content: str, plugin_root: str) -> str | None:
             capture_output=True, text=True, timeout=345600,
             env={**os.environ},
         )
+        # distinguish launcher failure from a successful review with zero annotations:
+        #   return None → caller falls back to plan-annotate.py (no overlay available,
+        #                 osascript error, empty term id, etc.)
+        #   return ""   → user reviewed the plan and added no annotations (approve)
+        #   return "<text>" → user added annotations (deny with feedback)
+        if result.returncode != 0:
+            return None
         annotations = result.stdout.strip()
         if not annotations:
             return ""

--- a/plugins/planning/scripts/plan-review-hook.py
+++ b/plugins/planning/scripts/plan-review-hook.py
@@ -76,13 +76,21 @@ def try_revdiff(plan_content: str, plugin_root: str) -> str | None:
             capture_output=True, text=True, timeout=345600,
             env={**os.environ},
         )
-        # distinguish launcher failure from a successful review with zero annotations:
-        #   return None → caller falls back to plan-annotate.py (no overlay available,
-        #                 osascript error, empty term id, etc.)
-        #   return ""   → user reviewed the plan and added no annotations (approve)
-        #   return "<text>" → user added annotations (deny with feedback)
-        if result.returncode != 0:
+        # distinguish launcher outcomes:
+        #   exit 127     → no overlay terminal available; fall back to plan-annotate.py
+        #   other non-0 → overlay was attempted but launcher/revdiff failed; surface
+        #                 as a deny reason so the user sees the actual error instead
+        #                 of a silent second review UI popping up
+        #   exit 0, ""   → user reviewed the plan and added no annotations (approve)
+        #   exit 0, text → user added annotations (deny with feedback)
+        if result.returncode == 127:
             return None
+        if result.returncode != 0:
+            stderr_text = (result.stderr or "").strip()[:500] or "no stderr output"
+            return (
+                f"revdiff review failed (exit {result.returncode}): {stderr_text}\n\n"
+                "revise the plan or try again."
+            )
         annotations = result.stdout.strip()
         if not annotations:
             return ""
@@ -134,8 +142,17 @@ def main() -> None:
     output = fallback.stdout.strip()
     if output:
         print(output)
-    else:
-        make_response("ask", "plan reviewed, no changes")
+        return
+    # empty stdout + non-zero exit means plan-annotate.py crashed — surface the
+    # error instead of silently approving the unreviewed plan.
+    if fallback.returncode != 0:
+        stderr_text = (fallback.stderr or "").strip()[:500] or "no stderr output"
+        make_response(
+            "ask",
+            f"plan-annotate.py failed (exit {fallback.returncode}): {stderr_text}",
+        )
+        return
+    make_response("ask", "plan reviewed, no changes")
 
 
 if __name__ == "__main__":

--- a/plugins/review/.claude-plugin/plugin.json
+++ b/plugins/review/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "review",
   "description": "PR review, interactive git diff annotation review, and writing style guide",
-  "version": "2.2.1",
+  "version": "2.3.0",
   "author": {
     "name": "Umputun"
   },

--- a/plugins/review/skills/git-review/SKILL.md
+++ b/plugins/review/skills/git-review/SKILL.md
@@ -17,7 +17,7 @@ Interactive annotation-based code review using editor overlays.
 ## How It Works
 
 1. Script generates a cleaned-up diff file (friendly headers, no technical noise)
-2. Opens in `$EDITOR` via tmux popup, kitty overlay, or wezterm split-pane
+2. Opens in `$EDITOR` via tmux popup, kitty overlay, wezterm split-pane, or ghostty split
 3. User adds annotations (comments, change requests) directly in the file
 4. Script returns user's annotations as a git diff
 5. Claude reads annotations, fixes code in the real repo
@@ -101,7 +101,8 @@ User: "review my changes"
 
 ## Requirements
 
-- tmux, kitty, or wezterm terminal (for editor overlay)
+- tmux, kitty, wezterm, or ghostty terminal (for editor overlay)
 - `$EDITOR` set (defaults to micro)
 - git
 - kitty users: kitty.conf must have `allow_remote_control yes` and `listen_on unix:/tmp/kitty-$KITTY_PID`
+- ghostty users: requires Ghostty 1.3.0+ on macOS (uses AppleScript)

--- a/plugins/review/skills/git-review/scripts/git-review.py
+++ b/plugins/review/skills/git-review/scripts/git-review.py
@@ -262,7 +262,9 @@ def open_editor(filepath: Path) -> int:
     # resolve the first token of $EDITOR to an absolute path so that
     # sh -c (used by kitty/wezterm/ghostty overlays) can find the binary
     # even when /opt/homebrew/bin or similar dirs are not in sh's default PATH.
-    editor_parts = shlex.split(editor)
+    # fall back to 'micro' if $EDITOR is unset, empty, or whitespace-only —
+    # shlex.split returns [] for those, which would crash on indexing.
+    editor_parts = shlex.split(editor) or ["micro"]
     resolved = shutil.which(editor_parts[0])
     if resolved:
         editor_parts[0] = resolved
@@ -357,37 +359,38 @@ def open_editor(filepath: Path) -> int:
     end tell
 end run
 """
-        result = subprocess.run(
-            ["osascript", "-", str(launch_script_path), str(Path.cwd())],
-            input=applescript, text=True, capture_output=True,
-        )
-        if result.returncode != 0:
-            launch_script_path.unlink(missing_ok=True)
-            sentinel.unlink(missing_ok=True)
-            return 1
-        ghostty_term_id = result.stdout.strip()
-        if not ghostty_term_id:
-            # AppleScript succeeded but returned nothing — bail out rather
-            # than blocking forever or running the close script on empty id.
-            launch_script_path.unlink(missing_ok=True)
-            sentinel.unlink(missing_ok=True)
-            return 1
-
-        while not sentinel.exists():
-            time.sleep(0.3)
-
-        # dismiss Ghostty's default "press any key to close" prompt
         close_applescript = """on run argv
     tell application "Ghostty" to close terminal id (item 1 of argv)
 end run
 """
-        subprocess.run(
-            ["osascript", "-", ghostty_term_id],
-            input=close_applescript, text=True, capture_output=True,
-        )
-        sentinel.unlink(missing_ok=True)
-        launch_script_path.unlink(missing_ok=True)
-        return 0
+        ghostty_term_id = ""
+        try:
+            result = subprocess.run(
+                ["osascript", "-", str(launch_script_path), str(Path.cwd())],
+                input=applescript, text=True, capture_output=True,
+            )
+            if result.returncode != 0:
+                return 1
+            ghostty_term_id = result.stdout.strip()
+            if not ghostty_term_id:
+                # AppleScript succeeded but returned nothing — bail out rather
+                # than blocking forever or running the close script on empty id.
+                return 1
+
+            while not sentinel.exists():
+                time.sleep(0.3)
+            return 0
+        finally:
+            # best-effort cleanup: ensure sentinel, launcher script, and the
+            # Ghostty split pane don't leak on Ctrl-C or any other exception.
+            if ghostty_term_id:
+                subprocess.run(
+                    ["osascript", "-", ghostty_term_id],
+                    input=close_applescript, text=True, capture_output=True,
+                    check=False,
+                )
+            sentinel.unlink(missing_ok=True)
+            launch_script_path.unlink(missing_ok=True)
 
     return 1
 

--- a/plugins/review/skills/git-review/scripts/git-review.py
+++ b/plugins/review/skills/git-review/scripts/git-review.py
@@ -1,9 +1,10 @@
 #!/usr/bin/env python3
 """git-review.py - interactive git diff annotation tool.
 
-generates a cleaned-up diff file, opens it in $EDITOR via tmux/kitty/wezterm/ghostty overlay,
-and tracks user annotations via a git repo in /tmp. returns the user's
-annotations (additions/edits) as a git diff on stdout.
+generates a cleaned-up diff file, opens it in $EDITOR via a
+tmux/kitty/wezterm/ghostty overlay, and tracks user annotations via a
+git repo in /tmp. returns the user's annotations (additions/edits) as a
+git diff on stdout.
 
 usage:
     git-review.py                          # auto-detect: uncommitted or branch vs default
@@ -20,10 +21,11 @@ each invocation regenerates the cleaned diff, commits it, opens the editor,
 and returns `git diff` output showing what the user changed.
 
 requirements:
-    - tmux, kitty, wezterm, or ghostty terminal (tmux tried first, then kitty, then wezterm, then ghostty)
+    - tmux, kitty, wezterm, or ghostty terminal (tried in that order)
     - $EDITOR set (defaults to micro)
     - git
-    - kitty users: kitty.conf must have allow_remote_control and listen_on configured
+    - kitty users: kitty.conf must have allow_remote_control and
+      listen_on configured
     - ghostty users: requires Ghostty 1.3.0+ on macOS (uses AppleScript)
 """
 
@@ -256,8 +258,10 @@ def setup_review_repo(review_dir: Path, content: str) -> None:
 
 
 def open_editor(filepath: Path) -> int:
-    """open file in $EDITOR via tmux popup, kitty overlay, wezterm split-pane, or ghostty split, blocking until editor closes.
-    tries tmux first (if $TMUX is set), then kitty, then wezterm, then ghostty. returns non-zero if none is available."""
+    """open file in $EDITOR via tmux popup, kitty overlay, wezterm
+    split-pane, or ghostty split, blocking until editor closes. tries
+    tmux first (if $TMUX is set), then kitty, then wezterm, then
+    ghostty. returns non-zero if none is available."""
     editor = os.environ.get("EDITOR", "micro")
     # resolve the first token of $EDITOR to an absolute path so that
     # sh -c (used by kitty/wezterm/ghostty overlays) can find the binary

--- a/plugins/review/skills/git-review/scripts/git-review.py
+++ b/plugins/review/skills/git-review/scripts/git-review.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """git-review.py - interactive git diff annotation tool.
 
-generates a cleaned-up diff file, opens it in $EDITOR via tmux/kitty/wezterm overlay,
+generates a cleaned-up diff file, opens it in $EDITOR via tmux/kitty/wezterm/ghostty overlay,
 and tracks user annotations via a git repo in /tmp. returns the user's
 annotations (additions/edits) as a git diff on stdout.
 
@@ -20,10 +20,11 @@ each invocation regenerates the cleaned diff, commits it, opens the editor,
 and returns `git diff` output showing what the user changed.
 
 requirements:
-    - tmux, kitty, or wezterm terminal (tmux tried first, then kitty, then wezterm)
+    - tmux, kitty, wezterm, or ghostty terminal (tmux tried first, then kitty, then wezterm, then ghostty)
     - $EDITOR set (defaults to micro)
     - git
     - kitty users: kitty.conf must have allow_remote_control and listen_on configured
+    - ghostty users: requires Ghostty 1.3.0+ on macOS (uses AppleScript)
 """
 
 import os
@@ -255,8 +256,8 @@ def setup_review_repo(review_dir: Path, content: str) -> None:
 
 
 def open_editor(filepath: Path) -> int:
-    """open file in $EDITOR via tmux popup, kitty overlay, or wezterm split-pane, blocking until editor closes.
-    tries tmux first (if $TMUX is set), then kitty, then wezterm. returns non-zero if none is available."""
+    """open file in $EDITOR via tmux popup, kitty overlay, wezterm split-pane, or ghostty split, blocking until editor closes.
+    tries tmux first (if $TMUX is set), then kitty, then wezterm, then ghostty. returns non-zero if none is available."""
     editor = os.environ.get("EDITOR", "micro")
 
     # tmux: display-popup -E blocks until the command exits, no sentinel needed
@@ -308,6 +309,67 @@ def open_editor(filepath: Path) -> int:
         while not sentinel.exists():
             time.sleep(0.3)
         sentinel.unlink(missing_ok=True)
+        return 0
+
+    # ghostty: split pane via AppleScript (macOS only, requires Ghostty 1.3.0+).
+    # cmux sets TERM_PROGRAM=ghostty too; guard on CMUX_SURFACE_ID to avoid
+    # misrouting a cmux session into a real-Ghostty AppleScript split.
+    if (
+        os.environ.get("TERM_PROGRAM") == "ghostty"
+        and not os.environ.get("CMUX_SURFACE_ID")
+        and shutil.which("osascript")
+    ):
+        fd, sentinel_path = tempfile.mkstemp(prefix="review-done-")
+        os.close(fd)
+        os.unlink(sentinel_path)
+        sentinel = Path(sentinel_path)
+        wrapper = f'{shlex.quote(editor)} {shlex.quote(str(filepath))}; touch {shlex.quote(str(sentinel))}'
+
+        launcher = tempfile.NamedTemporaryFile(
+            mode="w", suffix=".sh", prefix="review-launch-", delete=False
+        )
+        launcher.write(f"#!/bin/sh\n{wrapper}\n")
+        launcher.close()
+        launch_script_path = Path(launcher.name)
+        os.chmod(launch_script_path, 0o755)
+
+        applescript = """on run argv
+    set launchScript to item 1 of argv
+    tell application "Ghostty"
+        set cfg to new surface configuration
+        set command of cfg to launchScript
+        set wait after command of cfg to false
+        set ft to focused terminal of selected tab of front window
+        set newTerm to split ft direction down with configuration cfg
+        perform action "toggle_split_zoom" on newTerm
+        return id of newTerm
+    end tell
+end run
+"""
+        result = subprocess.run(
+            ["osascript", "-", str(launch_script_path)],
+            input=applescript, text=True, capture_output=True,
+        )
+        if result.returncode != 0:
+            launch_script_path.unlink(missing_ok=True)
+            sentinel.unlink(missing_ok=True)
+            return 1
+        ghostty_term_id = result.stdout.strip()
+
+        while not sentinel.exists():
+            time.sleep(0.3)
+
+        # dismiss Ghostty's default "press any key to close" prompt
+        close_applescript = """on run argv
+    tell application "Ghostty" to close terminal id (item 1 of argv)
+end run
+"""
+        subprocess.run(
+            ["osascript", "-", ghostty_term_id],
+            input=close_applescript, text=True, capture_output=True,
+        )
+        sentinel.unlink(missing_ok=True)
+        launch_script_path.unlink(missing_ok=True)
         return 0
 
     return 1
@@ -370,7 +432,7 @@ def run_review(base_ref: str | None = None, branch: str | None = None) -> None:
 
     review_file = review_dir / "review.diff"
     if open_editor(review_file) != 0:
-        print("error: no overlay terminal available (requires tmux, kitty, or wezterm)", file=sys.stderr)
+        print("error: no overlay terminal available (requires tmux, kitty, wezterm, or ghostty)", file=sys.stderr)
         sys.exit(1)
 
     # get annotations

--- a/plugins/review/skills/git-review/scripts/git-review.py
+++ b/plugins/review/skills/git-review/scripts/git-review.py
@@ -259,12 +259,21 @@ def open_editor(filepath: Path) -> int:
     """open file in $EDITOR via tmux popup, kitty overlay, wezterm split-pane, or ghostty split, blocking until editor closes.
     tries tmux first (if $TMUX is set), then kitty, then wezterm, then ghostty. returns non-zero if none is available."""
     editor = os.environ.get("EDITOR", "micro")
+    # resolve the first token of $EDITOR to an absolute path so that
+    # sh -c (used by kitty/wezterm/ghostty overlays) can find the binary
+    # even when /opt/homebrew/bin or similar dirs are not in sh's default PATH.
+    editor_parts = shlex.split(editor)
+    resolved = shutil.which(editor_parts[0])
+    if resolved:
+        editor_parts[0] = resolved
+    editor_cmd = " ".join(shlex.quote(p) for p in editor_parts)
 
     # tmux: display-popup -E blocks until the command exits, no sentinel needed
     if os.environ.get("TMUX") and shutil.which("tmux"):
         result = subprocess.run(
             ["tmux", "display-popup", "-E", "-w", "90%", "-h", "90%",
-             "-T", " Git Review ", "--", editor, str(filepath)],
+             "-T", " Git Review ", "--", "sh", "-c",
+             f'{editor_cmd} {shlex.quote(str(filepath))}'],
             stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
         )
         return result.returncode
@@ -279,7 +288,7 @@ def open_editor(filepath: Path) -> int:
         os.close(fd)
         os.unlink(sentinel_path)
         sentinel = Path(sentinel_path)
-        wrapper = f'{shlex.quote(editor)} {shlex.quote(str(filepath))}; touch {shlex.quote(str(sentinel))}'
+        wrapper = f'{editor_cmd} {shlex.quote(str(filepath))}; touch {shlex.quote(str(sentinel))}'
         cmd = ["kitty", "@", "--to", kitty_sock, "launch", "--type=overlay",
                f"--title=Git Review: {filepath.name}"]
         # target the kitty window where claude is running, not the active one
@@ -300,7 +309,7 @@ def open_editor(filepath: Path) -> int:
         os.close(fd)
         os.unlink(sentinel_path)
         sentinel = Path(sentinel_path)
-        wrapper = f'{shlex.quote(editor)} {shlex.quote(str(filepath))}; touch {shlex.quote(str(sentinel))}'
+        wrapper = f'{editor_cmd} {shlex.quote(str(filepath))}; touch {shlex.quote(str(sentinel))}'
         subprocess.run(
             ["wezterm", "cli", "split-pane", "--bottom", "--percent", "80",
              "--pane-id", wezterm_pane, "--", "sh", "-c", wrapper],
@@ -323,7 +332,7 @@ def open_editor(filepath: Path) -> int:
         os.close(fd)
         os.unlink(sentinel_path)
         sentinel = Path(sentinel_path)
-        wrapper = f'{shlex.quote(editor)} {shlex.quote(str(filepath))}; touch {shlex.quote(str(sentinel))}'
+        wrapper = f'{editor_cmd} {shlex.quote(str(filepath))}; touch {shlex.quote(str(sentinel))}'
 
         launcher = tempfile.NamedTemporaryFile(
             mode="w", suffix=".sh", prefix="review-launch-", delete=False
@@ -335,9 +344,11 @@ def open_editor(filepath: Path) -> int:
 
         applescript = """on run argv
     set launchScript to item 1 of argv
+    set cwd to item 2 of argv
     tell application "Ghostty"
         set cfg to new surface configuration
         set command of cfg to launchScript
+        set initial working directory of cfg to cwd
         set wait after command of cfg to false
         set ft to focused terminal of selected tab of front window
         set newTerm to split ft direction down with configuration cfg
@@ -347,7 +358,7 @@ def open_editor(filepath: Path) -> int:
 end run
 """
         result = subprocess.run(
-            ["osascript", "-", str(launch_script_path)],
+            ["osascript", "-", str(launch_script_path), str(Path.cwd())],
             input=applescript, text=True, capture_output=True,
         )
         if result.returncode != 0:
@@ -355,6 +366,12 @@ end run
             sentinel.unlink(missing_ok=True)
             return 1
         ghostty_term_id = result.stdout.strip()
+        if not ghostty_term_id:
+            # AppleScript succeeded but returned nothing — bail out rather
+            # than blocking forever or running the close script on empty id.
+            launch_script_path.unlink(missing_ok=True)
+            sentinel.unlink(missing_ok=True)
+            return 1
 
         while not sentinel.exists():
             time.sleep(0.3)


### PR DESCRIPTION
## Summary

- Add Ghostty (1.3.0+, macOS) terminal overlay support to three scripts that previously supported only tmux/kitty/wezterm:
  - `plugins/planning/scripts/launch-plan-review.sh` — opens revdiff TUI in a Ghostty split
  - `plugins/planning/scripts/plan-annotate.py` — opens `$EDITOR` fallback in a Ghostty split
  - `plugins/review/skills/git-review/scripts/git-review.py` — opens `$EDITOR` in a Ghostty split for diff annotation
- Detection via `TERM_PROGRAM=ghostty` + `osascript` presence, guarded by `CMUX_SURFACE_ID` unset (cmux also sets `TERM_PROGRAM=ghostty`). Uses AppleScript `tell application "Ghostty" ... split ft direction down` with `toggle_split_zoom`, following the reference implementation in `umputun/revdiff`.
- Defensive hardening surfaced during review:
  - Resolve `$EDITOR` to absolute path in `git-review.py` (was missing; Ghostty surface's lean PATH made the bug visible)
  - Empty-`$EDITOR` fallback to `micro` via `shlex.split(editor) or ["micro"]` (avoids IndexError)
  - Empty `ghostty_term_id` bailout across all three scripts
  - try/finally cleanup of sentinel/launcher/Ghostty pane on `KeyboardInterrupt` (Python)
  - Extended EXIT trap in bash closes orphan Ghostty pane on interrupt
  - `initial working directory` passed to Ghostty surface (matches Python siblings)
  - `launch-plan-review.sh` now exits `127` for "no overlay available" (falls back); other non-zero exit codes surface as an "ask" response in `plan-review-hook.py` instead of silently approving or wrongly denying the plan
  - Fallback subprocess in `plan-review-hook.py` now checks returncode (symmetric fix)
- Docs and error messages updated consistently (`tmux, kitty, wezterm, or ghostty`)
- Plugin version bumps: planning 3.4.0 → 3.5.0, review 2.2.1 → 2.3.0
- Implementation plan: `docs/plans/completed/20260418-ghostty-overlay-support.md`