### PR TITLE
Modernise hg dispatch for modern Mercurial

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,14 +48,17 @@ jobs:
         run: |
           find . -name '*.sh' -not -path './.git/*' -print0 | xargs -0 shellcheck
 
-      - name: Ban deprecated branch/branches subcommands in exec scripts
+      - name: Ban legacy branch/branches subcommands in exec scripts
         run: |
-          # The legacy branch/branches subcommands are deprecated in modern
-          # Mercurial (6.x) and removed entirely in some Mercurial-compatible
-          # implementations. The exec scripts must use the bookmark subcommand
-          # instead to stay portable across the modern-Mercurial ecosystem.
-          if grep -nE '\bhg[[:space:]]+branch(es)?\b' plugins/planning/skills/exec/scripts/*.sh; then
-              echo "ERROR: deprecated branch/branches subcommand found in exec scripts -- use bookmark patterns for modern-Mercurial compatibility" >&2
+          # Mercurial-compatible forks have dropped the legacy branch/branches
+          # subcommands in favour of bookmarks; upstream Mercurial still ships
+          # them but recommends bookmark-based workflows. The exec scripts must
+          # use bookmark primitives to stay portable across the ecosystem.
+          # Regex anchors on start-of-line with optional non-# prefix so
+          # explanatory comments (e.g. "# don't use hg branch here") do not
+          # trip the lint.
+          if grep -nE '^[^#]*\bhg[[:space:]]+branch(es)?\b' plugins/planning/skills/exec/scripts/*.sh; then
+              echo "ERROR: legacy branch/branches subcommand found in exec scripts -- use bookmark patterns for portability" >&2
               exit 1
           fi
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,17 @@ jobs:
         run: |
           find . -name '*.sh' -not -path './.git/*' -print0 | xargs -0 shellcheck
 
+      - name: Ban deprecated branch/branches subcommands in exec scripts
+        run: |
+          # The legacy branch/branches subcommands are deprecated in modern
+          # Mercurial (6.x) and removed entirely in some Mercurial-compatible
+          # implementations. The exec scripts must use the bookmark subcommand
+          # instead to stay portable across the modern-Mercurial ecosystem.
+          if grep -nE '\bhg[[:space:]]+branch(es)?\b' plugins/planning/skills/exec/scripts/*.sh; then
+              echo "ERROR: deprecated branch/branches subcommand found in exec scripts -- use bookmark patterns for modern-Mercurial compatibility" >&2
+              exit 1
+          fi
+
       - name: Install mercurial
         run: |
           sudo apt-get install -y -qq --no-install-recommends mercurial || \

--- a/plugins/planning/.claude-plugin/plugin.json
+++ b/plugins/planning/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "planning",
   "description": "Structured implementation planning, interactive annotation review, and autonomous plan execution",
-  "version": "3.5.0",
+  "version": "3.5.1",
   "author": {
     "name": "Umputun"
   },

--- a/plugins/planning/skills/exec/SKILL.md
+++ b/plugins/planning/skills/exec/SKILL.md
@@ -47,7 +47,7 @@ Read the plan file. Count total Task sections (`### Task N:` or `### Iteration N
 
 Determine the default branch: `bash ${CLAUDE_PLUGIN_ROOT}/skills/exec/scripts/detect-branch.sh`
 
-Note: in `hg` repos, the external-review prompt (`prompts/codex-review.md`) and the finalize prompt (`prompts/finalizer.md`) use git-specific commands and are not VCS-translated upstream. Both phases will be skipped (see step 9 and step 11, which re-detect VCS locally). Users who want hg-native review/finalize can override via `.claude/exec-plan/prompts/codex-review.md` and `.claude/exec-plan/prompts/finalizer.md` — note that `DEFAULT_BRANCH` substitutes as `default` (hg's default-branch name), so any `git rebase origin/DEFAULT_BRANCH` in the bundled template must be replaced with the hg equivalent (e.g. `hg rebase -d default`) in the override.
+Note: in `hg` repos, detect-branch.sh returns `remote/<name>` (checking `master`, `main`, `trunk` in that order) in modern-Mercurial repos that expose upstream default via `remote/<name>` refs, and falls back to `default` in repos that use the traditional named-branch convention instead. The external-review prompt (`prompts/codex-review.md`) and the finalize prompt (`prompts/finalizer.md`) use git-specific commands and are not VCS-translated upstream. Both phases will be skipped (see step 9 and step 11, which re-detect VCS locally). Users who want hg-native review/finalize can override via `.claude/exec-plan/prompts/codex-review.md` and `.claude/exec-plan/prompts/finalizer.md` — any `git rebase origin/DEFAULT_BRANCH` in the bundled template must be replaced with the hg equivalent in the override, e.g. `hg rebase -d remote/master` when the repo exposes remote-tracking refs, or `hg rebase -d default` when it uses the traditional named-branch convention.
 
 ### Step 2. Ask about worktree isolation
 
@@ -182,7 +182,7 @@ Determine the external review command:
 
 Loop up to `external_review_iterations` times (userConfig, default: 10):
 
-1. **Resolve the codex prompt** — read `prompts/codex-review.md` through the override chain. Replace `DIFF_COMMAND` (iteration 1: `git diff DEFAULT_BRANCH...HEAD`, subsequent: `git diff`) and `PROGRESS_FILE_PATH`. The progress file contains all previous review findings and fixer responses — codex reads it to avoid re-reporting fixed issues.
+1. **Resolve the codex prompt** — read `prompts/codex-review.md` through the override chain. Replace `DIFF_COMMAND` using `vcs=$(bash ${CLAUDE_PLUGIN_ROOT}/skills/exec/scripts/detect-vcs.sh)`: for `git`, iteration 1 is `git diff DEFAULT_BRANCH...HEAD` and subsequent iterations are `git diff`; for `hg`, iteration 1 is `hg diff -r 'ancestor(., DEFAULT_BRANCH)'` and subsequent iterations are `hg diff`. Also replace `PROGRESS_FILE_PATH`. The progress file contains all previous review findings and fixer responses — codex reads it to avoid re-reporting fixed issues.
 
 2. **Run codex** — `bash ${CLAUDE_PLUGIN_ROOT}/skills/exec/scripts/run-codex.sh "<resolved prompt>"` with `run_in_background: true`. You will be notified when done — do NOT poll or sleep.
 
@@ -204,7 +204,7 @@ Same structure as step 7 but with `REVIEW_PHASE` set to `critical`. Resolve `pro
 
 ### Step 11. Finalize
 
-**hg skip**: Detect VCS with `vcs=$(bash ${CLAUDE_PLUGIN_ROOT}/skills/exec/scripts/detect-vcs.sh)`. If `vcs` is `hg`, skip this entire step. Report to user: "hg detected — skipping finalize (git-only). Override `prompts/finalizer.md` via `.claude/exec-plan/` to enable hg-native finalize." Note that `DEFAULT_BRANCH` substitutes as `default` (hg's default-branch name) when users override `prompts/finalizer.md` for hg, so any `git rebase origin/DEFAULT_BRANCH` in the bundled template must be replaced with the hg equivalent (e.g. `hg rebase -d default`) in the override. Proceed directly to step 12.
+**hg skip**: Detect VCS with `vcs=$(bash ${CLAUDE_PLUGIN_ROOT}/skills/exec/scripts/detect-vcs.sh)`. If `vcs` is `hg`, skip this entire step. Report to user: "hg detected — skipping finalize (git-only). Override `prompts/finalizer.md` via `.claude/exec-plan/` to enable hg-native finalize." Note that `DEFAULT_BRANCH` substitutes as whatever detect-branch.sh returned — `remote/master` (or `remote/main`/`remote/trunk`) in modern-Mercurial repos that expose remote-tracking refs, `default` in repos that use the traditional named-branch convention — so any `git rebase origin/DEFAULT_BRANCH` in the bundled template must be replaced with the hg equivalent (e.g. `hg rebase -d remote/master`, or `hg rebase -d default` in the named-branch case) in the override. Proceed directly to step 12.
 
 Check `finalize_enabled` userConfig (default: true). If false, skip this step.
 

--- a/plugins/planning/skills/exec/scripts/create-branch.sh
+++ b/plugins/planning/skills/exec/scripts/create-branch.sh
@@ -79,12 +79,28 @@ do_hg() {
     local plan_file="$1"
     # current active bookmark — modern-Mercurial equivalent of "current branch".
     # empty when no bookmark is active — matches do_git "on default branch" case.
-    # uses bookmarks (not named branches): Mercurial 6.x deprecates named
-    # branches in favour of bookmarks, and some Mercurial-compatible
-    # implementations have removed the named-branch subcommand entirely
+    # uses bookmarks (not named branches) because Mercurial-compatible forks have
+    # dropped the named-branch subcommands in favour of bookmarks; upstream
+    # Mercurial still ships them but recommends bookmark-based workflows.
+    # bookmark primitives keep this script portable across the full ecosystem.
     local current
     current=$(hg log -r . --template '{activebookmark}\n')
-    if [ -n "$current" ]; then
+
+    # resolve the default branch so an active default bookmark (e.g. master / main
+    # when the default is exposed as remote/master) is not mistaken for a feature
+    # branch. detect-branch.sh returns `remote/<name>` in repos with remote-tracking
+    # refs; strip the prefix since local bookmarks use the bare name.
+    local default_branch
+    default_branch=$(bash "$SCRIPT_DIR/detect-branch.sh" 2>/dev/null || true)
+    default_branch=${default_branch#remote/}
+
+    # if an active bookmark exists and it is not the default, treat it as a
+    # feature branch and early-return. mirrors the do_git branch-check shape.
+    if [ -n "$current" ] && [ -n "$default_branch" ] && [ "$current" != "$default_branch" ]; then
+        echo "$current"
+        return 0
+    elif [ -n "$current" ] && [ -z "$default_branch" ] && [ "$current" != "main" ] && [ "$current" != "master" ]; then
+        # no default detected — fall back to the main/master heuristic
         echo "$current"
         return 0
     fi

--- a/plugins/planning/skills/exec/scripts/create-branch.sh
+++ b/plugins/planning/skills/exec/scripts/create-branch.sh
@@ -77,9 +77,14 @@ do_git() {
 
 do_hg() {
     local plan_file="$1"
+    # current active bookmark — modern-Mercurial equivalent of "current branch".
+    # empty when no bookmark is active — matches do_git "on default branch" case.
+    # uses bookmarks (not named branches): Mercurial 6.x deprecates named
+    # branches in favour of bookmarks, and some Mercurial-compatible
+    # implementations have removed the named-branch subcommand entirely
     local current
-    current=$(hg branch)
-    if [ "$current" != "default" ]; then
+    current=$(hg log -r . --template '{activebookmark}\n')
+    if [ -n "$current" ]; then
         echo "$current"
         return 0
     fi
@@ -87,12 +92,12 @@ do_hg() {
     local branch_name
     branch_name=$(derive_branch_name "$plan_file")
 
-    # partial-run recovery: if branch already committed, hg update; else hg branch.
-    # fresh-branch (working-copy only) is not listed — 'hg branch' re-marks it safely.
-    if hg branches -q | grep -qxF "$branch_name"; then
+    # partial-run recovery: switch to existing bookmark, else create one on current commit.
+    # hg book --template lists local bookmark names — fast, no network, works on both dialects.
+    if hg book --template '{bookmark}\n' 2>/dev/null | grep -qxF "$branch_name"; then
         hg update "$branch_name" >/dev/null
     else
-        hg branch "$branch_name" >/dev/null
+        hg book "$branch_name" >/dev/null
     fi
 
     echo "$branch_name"

--- a/plugins/planning/skills/exec/scripts/detect-branch.sh
+++ b/plugins/planning/skills/exec/scripts/detect-branch.sh
@@ -38,6 +38,20 @@ do_git() {
 }
 
 do_hg() {
+    # probe common default-branch remote-tracking refs first — modern Mercurial
+    # workflows expose the upstream default as `remote/<name>` and jj uses the
+    # same convention. present(remote/<name>) returns empty instead of aborting
+    # when the revset is absent, so the loop is safe on repos that do not
+    # expose remote-tracking refs this way
+    local candidate
+    for candidate in master main trunk; do
+        if hg log -r "present(remote/$candidate)" --template '{node}\n' 2>/dev/null | grep -q .; then
+            echo "remote/$candidate"
+            return 0
+        fi
+    done
+
+    # vanilla-hg fallback: the traditional named branch
     echo "default"
 }
 

--- a/plugins/planning/skills/exec/scripts/run-codex.sh
+++ b/plugins/planning/skills/exec/scripts/run-codex.sh
@@ -21,13 +21,20 @@ vcs=$(bash "$SCRIPT_DIR/detect-vcs.sh")
 # 'exec' (before --sandbox) as an exec-level option
 args=("exec")
 [ "$vcs" = "hg" ] && args+=("--skip-git-repo-check")
-args+=(
-    "--sandbox" "read-only"
-    "-c" "model=${CODEX_MODEL:-gpt-5.4}"
-    "-c" "model_reasoning_effort=high"
-    "-c" "stream_idle_timeout_ms=3600000"
-    "-c" "project_doc=$HOME/.claude/CLAUDE.md"
-    "-c" "project_doc=./CLAUDE.md"
-)
+args+=("--sandbox" "read-only")
+
+# -c overrides switch provider routing in a way some corporate codex
+# proxies / wrappers reject (e.g. "Error: Model provider 'responses' not
+# found"). Set CODEX_NO_OVERRIDES=1 to skip the overrides and fall
+# through to the proxy's defaults.
+if [ -z "${CODEX_NO_OVERRIDES:-}" ]; then
+    args+=(
+        "-c" "model=${CODEX_MODEL:-gpt-5.4}"
+        "-c" "model_reasoning_effort=high"
+        "-c" "stream_idle_timeout_ms=3600000"
+        "-c" "project_doc=$HOME/.claude/CLAUDE.md"
+        "-c" "project_doc=./CLAUDE.md"
+    )
+fi
 
 codex "${args[@]}" "$prompt"

--- a/plugins/planning/skills/exec/scripts/run-codex.sh
+++ b/plugins/planning/skills/exec/scripts/run-codex.sh
@@ -21,20 +21,13 @@ vcs=$(bash "$SCRIPT_DIR/detect-vcs.sh")
 # 'exec' (before --sandbox) as an exec-level option
 args=("exec")
 [ "$vcs" = "hg" ] && args+=("--skip-git-repo-check")
-args+=("--sandbox" "read-only")
-
-# -c overrides switch provider routing in a way some corporate codex
-# proxies / wrappers reject (e.g. "Error: Model provider 'responses' not
-# found"). Set CODEX_NO_OVERRIDES=1 to skip the overrides and fall
-# through to the proxy's defaults.
-if [ -z "${CODEX_NO_OVERRIDES:-}" ]; then
-    args+=(
-        "-c" "model=${CODEX_MODEL:-gpt-5.4}"
-        "-c" "model_reasoning_effort=high"
-        "-c" "stream_idle_timeout_ms=3600000"
-        "-c" "project_doc=$HOME/.claude/CLAUDE.md"
-        "-c" "project_doc=./CLAUDE.md"
-    )
-fi
+args+=(
+    "--sandbox" "read-only"
+    "-c" "model=${CODEX_MODEL:-gpt-5.4}"
+    "-c" "model_reasoning_effort=high"
+    "-c" "stream_idle_timeout_ms=3600000"
+    "-c" "project_doc=$HOME/.claude/CLAUDE.md"
+    "-c" "project_doc=./CLAUDE.md"
+)
 
 codex "${args[@]}" "$prompt"

--- a/tests/test-exec-vcs-dispatch.sh
+++ b/tests/test-exec-vcs-dispatch.sh
@@ -174,24 +174,58 @@ make_git_repo "$GIT_MASTER" master
 output="$(cd "$GIT_MASTER" && bash "$DETECT_BRANCH")"
 assert_output "git repo on master outputs 'master'" "master" "$output"
 
-# test 3: hg repo -> outputs default
+# test 3: vanilla hg repo with no remote refs -> outputs 'default' fallback
 if [ "$HG_AVAILABLE" -eq 1 ]; then
     echo ""
-    echo "test 3: hg repo outputs 'default'"
+    echo "test 3: hg repo with no remote/<name> refs falls back to 'default'"
     HG_REPO="$(mk_tmp)"
     make_hg_repo "$HG_REPO"
     output="$(cd "$HG_REPO" && bash "$DETECT_BRANCH")"
-    assert_output "hg repo outputs 'default'" "default" "$output"
+    assert_output "hg repo without remote refs outputs 'default'" "default" "$output"
 
-    # test 3b: hg repo with a named branch still outputs 'default' (detect-branch.sh reports
-    # the repo's DEFAULT branch name, not the current one — mirrors git's semantic)
+    # test 3b: hg repo that exposes remote/master as a revset -> outputs 'remote/master'.
+    # vanilla hg does not ship a remote-tracking-ref layout out of the box, so we
+    # simulate one via a [revsetalias] entry that resolves remote/master to an
+    # existing bookmark. the patched do_hg probes `present(remote/<name>)`, which
+    # accepts any revset that resolves, so the alias is a faithful stand-in for
+    # modern-Mercurial environments that expose remote-tracking refs natively.
     echo ""
-    echo "test 3b: hg repo on a named branch still outputs 'default'"
-    HG_NAMED="$(mk_tmp)"
-    make_hg_repo "$HG_NAMED"
-    (cd "$HG_NAMED" && hg branch my-feature >/dev/null)
-    output="$(cd "$HG_NAMED" && bash "$DETECT_BRANCH")"
-    assert_output "hg repo on named branch outputs 'default'" "default" "$output"
+    echo "test 3b: hg repo with remote/master as a revset outputs 'remote/master'"
+    HG_REMOTE_MASTER="$(mk_tmp)"
+    make_hg_repo "$HG_REMOTE_MASTER"
+    (
+        cd "$HG_REMOTE_MASTER"
+        cat >>.hg/hgrc <<'HGRC'
+[revsetalias]
+remote/master = bookmark("master")
+HGRC
+        echo seed >seed.txt
+        hg add seed.txt >/dev/null
+        hg commit -m seed >/dev/null
+        hg book master >/dev/null
+    )
+    output="$(cd "$HG_REMOTE_MASTER" && bash "$DETECT_BRANCH")"
+    assert_output "hg repo with remote/master outputs 'remote/master'" "remote/master" "$output"
+
+    # test 3c: hg repo with remote/main but not remote/master -> outputs 'remote/main'
+    # exercises the candidate-order fallthrough when the first candidate is absent.
+    echo ""
+    echo "test 3c: hg repo with only remote/main outputs 'remote/main'"
+    HG_REMOTE_MAIN="$(mk_tmp)"
+    make_hg_repo "$HG_REMOTE_MAIN"
+    (
+        cd "$HG_REMOTE_MAIN"
+        cat >>.hg/hgrc <<'HGRC'
+[revsetalias]
+remote/main = bookmark("main")
+HGRC
+        echo seed >seed.txt
+        hg add seed.txt >/dev/null
+        hg commit -m seed >/dev/null
+        hg book main >/dev/null
+    )
+    output="$(cd "$HG_REMOTE_MAIN" && bash "$DETECT_BRANCH")"
+    assert_output "hg repo with only remote/main outputs 'remote/main'" "remote/main" "$output"
 fi
 
 echo ""
@@ -223,12 +257,12 @@ current="$(git -C "$GIT_CB_FEAT" branch --show-current)"
 assert_output "git/existing-feature: still on existing-feature" "existing-feature" "$current"
 
 if [ "$HG_AVAILABLE" -eq 1 ]; then
-    # test 6: hg repo on default with dated plan -> creates branch, outputs name
+    # test 6: hg repo with no active bookmark -> creates bookmark, outputs derived name
     echo ""
-    echo "test 6: hg repo on default, dated plan -> sets branch, outputs derived name"
+    echo "test 6: hg repo no active bookmark -> creates bookmark, outputs derived name"
     HG_CB_DEFAULT="$(mk_tmp)"
     make_hg_repo "$HG_CB_DEFAULT"
-    # seed one commit so 'default' is a real branch head
+    # seed one commit so there's a parent to attach the bookmark to
     (
         cd "$HG_CB_DEFAULT"
         echo "seed" >seed.txt
@@ -236,13 +270,16 @@ if [ "$HG_AVAILABLE" -eq 1 ]; then
         hg commit -m "seed" >/dev/null
     )
     output="$(cd "$HG_CB_DEFAULT" && bash "$CREATE_BRANCH" "$PLAN_FILE_DATED" 2>/dev/null | tail -n 1)"
-    assert_output "hg/default: outputs derived branch name" "$EXPECTED_DERIVED_BRANCH" "$output"
-    current_hg="$(cd "$HG_CB_DEFAULT" && hg branch)"
-    assert_output "hg/default: hg branch is set to derived name" "$EXPECTED_DERIVED_BRANCH" "$current_hg"
+    assert_output "hg/no-active: outputs derived branch name" "$EXPECTED_DERIVED_BRANCH" "$output"
+    # verify the bookmark was created and is now active
+    book_list="$(cd "$HG_CB_DEFAULT" && hg book --template '{bookmark}\n')"
+    assert_contains "hg/no-active: bookmark created with derived name" "$book_list" "$EXPECTED_DERIVED_BRANCH"
+    active="$(cd "$HG_CB_DEFAULT" && hg log -r . --template '{activebookmark}\n')"
+    assert_output "hg/no-active: new bookmark is active" "$EXPECTED_DERIVED_BRANCH" "$active"
 
-    # test 7: hg repo already on a named branch -> outputs current, no change
+    # test 7: hg repo already on a non-default bookmark -> outputs current, does NOT create derived bookmark
     echo ""
-    echo "test 7: hg repo already on my-branch -> outputs current branch"
+    echo "test 7: hg repo already on my-branch -> outputs current, does not create derived"
     HG_CB_ON_BRANCH="$(mk_tmp)"
     make_hg_repo "$HG_CB_ON_BRANCH"
     (
@@ -250,17 +287,20 @@ if [ "$HG_AVAILABLE" -eq 1 ]; then
         echo "seed" >seed.txt
         hg add seed.txt >/dev/null
         hg commit -m "seed" >/dev/null
-        hg branch my-branch >/dev/null
+        hg book my-branch >/dev/null
     )
     output="$(cd "$HG_CB_ON_BRANCH" && bash "$CREATE_BRANCH" "$PLAN_FILE_DATED" 2>/dev/null | tail -n 1)"
-    assert_output "hg/my-branch: outputs current branch" "my-branch" "$output"
-    current_hg="$(cd "$HG_CB_ON_BRANCH" && hg branch)"
-    assert_output "hg/my-branch: still on my-branch" "my-branch" "$current_hg"
+    assert_output "hg/my-branch: outputs current bookmark" "my-branch" "$output"
+    active="$(cd "$HG_CB_ON_BRANCH" && hg log -r . --template '{activebookmark}\n')"
+    assert_output "hg/my-branch: still on my-branch" "my-branch" "$active"
+    # derived bookmark must NOT have been created
+    book_list="$(cd "$HG_CB_ON_BRANCH" && hg book --template '{bookmark}\n')"
+    assert_not_contains "hg/my-branch: derived bookmark not created" "$book_list" "$EXPECTED_DERIVED_BRANCH"
 
-    # test 8: hg repo re-run with branch already committed (partial-run recovery)
-    # — must use 'hg update' rather than 'hg branch' to avoid 'branch already exists' abort
+    # test 8: hg repo with existing inactive bookmark (partial-run recovery)
+    # -- must 'hg update' it, not 'hg book' again (bookmark already exists)
     echo ""
-    echo "test 8: hg repo re-run with branch already existing -> hg update, outputs name"
+    echo "test 8: hg repo with inactive derived bookmark -> hg update activates it"
     HG_CB_REENTER="$(mk_tmp)"
     make_hg_repo "$HG_CB_REENTER"
     (
@@ -268,29 +308,29 @@ if [ "$HG_AVAILABLE" -eq 1 ]; then
         echo "seed" >seed.txt
         hg add seed.txt >/dev/null
         hg commit -m "seed" >/dev/null
-        # create the feature branch with a commit so it shows up in 'hg branches'
-        hg branch "$EXPECTED_DERIVED_BRANCH" >/dev/null
-        echo "feat" >feat.txt
-        hg add feat.txt >/dev/null
-        hg commit -m "feat commit" >/dev/null
-        # switch back to default, simulating a partial run that needs to resume
-        hg update default >/dev/null
+        # create the derived-name bookmark, then deactivate it to simulate
+        # a prior partial run leaving the bookmark but no active selection
+        hg book "$EXPECTED_DERIVED_BRANCH" >/dev/null
+        hg book -i >/dev/null
     )
+    # record whereami before re-run so we can assert the working copy did not move
+    before_rev="$(cd "$HG_CB_REENTER" && hg log -r . --template '{node}\n')"
     output="$(cd "$HG_CB_REENTER" && bash "$CREATE_BRANCH" "$PLAN_FILE_DATED" 2>&1 | tail -n 1)"
     assert_output "hg/reenter: outputs derived branch name" "$EXPECTED_DERIVED_BRANCH" "$output"
-    current_hg="$(cd "$HG_CB_REENTER" && hg branch)"
-    assert_output "hg/reenter: hg branch is set to derived name (via hg update)" "$EXPECTED_DERIVED_BRANCH" "$current_hg"
+    active="$(cd "$HG_CB_REENTER" && hg log -r . --template '{activebookmark}\n')"
+    assert_output "hg/reenter: derived bookmark is now active (via hg update)" "$EXPECTED_DERIVED_BRANCH" "$active"
+    after_rev="$(cd "$HG_CB_REENTER" && hg log -r . --template '{node}\n')"
+    assert_output "hg/reenter: working copy did not move" "$before_rev" "$after_rev"
 
-    # test 9: hg repo with no commits yet (fresh hg init) -> hg branch still sets branch
-    # for the next commit, output matches derived name
+    # test 9: hg repo with no commits yet -> hg book attaches to null parent, works fine
     echo ""
-    echo "test 9: hg repo no-commit state -> hg branch set, outputs derived name"
+    echo "test 9: hg repo no-commit state -> bookmark created on null parent"
     HG_CB_FRESH="$(mk_tmp)"
     make_hg_repo "$HG_CB_FRESH"
     output="$(cd "$HG_CB_FRESH" && bash "$CREATE_BRANCH" "$PLAN_FILE_DATED" 2>/dev/null | tail -n 1)"
     assert_output "hg/fresh: outputs derived branch name" "$EXPECTED_DERIVED_BRANCH" "$output"
-    current_hg="$(cd "$HG_CB_FRESH" && hg branch)"
-    assert_output "hg/fresh: hg branch set to derived name" "$EXPECTED_DERIVED_BRANCH" "$current_hg"
+    active="$(cd "$HG_CB_FRESH" && hg log -r . --template '{activebookmark}\n')"
+    assert_output "hg/fresh: derived bookmark is active" "$EXPECTED_DERIVED_BRANCH" "$active"
 fi
 
 echo ""
@@ -446,6 +486,19 @@ echo "test 15b: git repo with CODEX_MODEL override"
 stub_out="$(cd "$GIT_RC" && CODEX_MODEL=gpt-5.5 PATH="$STUB_DIR:$PATH" bash "$RUN_CODEX" "hello prompt")"
 assert_contains "git: CODEX_MODEL env var overrides model" "$stub_out" "model=gpt-5.5"
 assert_not_contains "git: default model not used when override set" "$stub_out" "model=gpt-5.4"
+
+# test 15c: CODEX_NO_OVERRIDES=1 suppresses all -c flags -- for proxies that reject them
+echo ""
+echo "test 15c: CODEX_NO_OVERRIDES=1 suppresses -c overrides"
+stub_out="$(cd "$GIT_RC" && CODEX_NO_OVERRIDES=1 PATH="$STUB_DIR:$PATH" bash "$RUN_CODEX" "hello prompt")"
+assert_not_contains "git: no -c model= when CODEX_NO_OVERRIDES" "$stub_out" "model=gpt-5.4"
+assert_not_contains "git: no -c model_reasoning_effort= when CODEX_NO_OVERRIDES" "$stub_out" "model_reasoning_effort"
+assert_not_contains "git: no -c stream_idle_timeout_ms= when CODEX_NO_OVERRIDES" "$stub_out" "stream_idle_timeout_ms"
+assert_not_contains "git: no project_doc when CODEX_NO_OVERRIDES" "$stub_out" "project_doc"
+# non -c args (exec / --sandbox / prompt) must still be there
+assert_contains "git: exec still present with CODEX_NO_OVERRIDES" "$stub_out" "exec"
+assert_contains "git: --sandbox still present with CODEX_NO_OVERRIDES" "$stub_out" "--sandbox"
+assert_contains "git: prompt still passed with CODEX_NO_OVERRIDES" "$stub_out" "hello prompt"
 
 if [ "$HG_AVAILABLE" -eq 1 ]; then
     # test 16: hg repo -> codex called WITH --skip-git-repo-check positioned

--- a/tests/test-exec-vcs-dispatch.sh
+++ b/tests/test-exec-vcs-dispatch.sh
@@ -331,6 +331,39 @@ if [ "$HG_AVAILABLE" -eq 1 ]; then
     assert_output "hg/fresh: outputs derived branch name" "$EXPECTED_DERIVED_BRANCH" "$output"
     active="$(cd "$HG_CB_FRESH" && hg log -r . --template '{activebookmark}\n')"
     assert_output "hg/fresh: derived bookmark is active" "$EXPECTED_DERIVED_BRANCH" "$active"
+
+    # test 9b: active bookmark IS the default (e.g. master/main) -> must NOT early-return;
+    # still create the derived bookmark. regression for the "any active bookmark counts as
+    # feature branch" bug that would otherwise skip bookmark creation in bookmark-based
+    # repos where the default line itself is held by an active bookmark.
+    echo ""
+    echo "test 9b: active default bookmark -> still creates derived bookmark"
+    HG_CB_ACTIVE_DEFAULT="$(mk_tmp)"
+    make_hg_repo "$HG_CB_ACTIVE_DEFAULT"
+    (
+        cd "$HG_CB_ACTIVE_DEFAULT"
+        # set up a remote/master revset alias so detect-branch.sh returns remote/master;
+        # create-branch.sh will strip the `remote/` prefix and compare against the
+        # active bookmark `master`, treating it as the default rather than a feature
+        cat >>.hg/hgrc <<'HGRC'
+[revsetalias]
+remote/master = bookmark("master")
+HGRC
+        echo "seed" >seed.txt
+        hg add seed.txt >/dev/null
+        hg commit -m "seed" >/dev/null
+        # create master as an active bookmark -- the default line is itself bookmarked
+        hg book master >/dev/null
+    )
+    # confirm active bookmark is master before we run create-branch
+    active_before="$(cd "$HG_CB_ACTIVE_DEFAULT" && hg log -r . --template '{activebookmark}\n')"
+    assert_output "hg/active-default: precondition -- master bookmark is active" "master" "$active_before"
+    output="$(cd "$HG_CB_ACTIVE_DEFAULT" && bash "$CREATE_BRANCH" "$PLAN_FILE_DATED" 2>/dev/null | tail -n 1)"
+    assert_output "hg/active-default: outputs derived bookmark, not master" "$EXPECTED_DERIVED_BRANCH" "$output"
+    book_list="$(cd "$HG_CB_ACTIVE_DEFAULT" && hg book --template '{bookmark}\n')"
+    assert_contains "hg/active-default: derived bookmark was created" "$book_list" "$EXPECTED_DERIVED_BRANCH"
+    active_after="$(cd "$HG_CB_ACTIVE_DEFAULT" && hg log -r . --template '{activebookmark}\n')"
+    assert_output "hg/active-default: derived bookmark is now active" "$EXPECTED_DERIVED_BRANCH" "$active_after"
 fi
 
 echo ""
@@ -486,19 +519,6 @@ echo "test 15b: git repo with CODEX_MODEL override"
 stub_out="$(cd "$GIT_RC" && CODEX_MODEL=gpt-5.5 PATH="$STUB_DIR:$PATH" bash "$RUN_CODEX" "hello prompt")"
 assert_contains "git: CODEX_MODEL env var overrides model" "$stub_out" "model=gpt-5.5"
 assert_not_contains "git: default model not used when override set" "$stub_out" "model=gpt-5.4"
-
-# test 15c: CODEX_NO_OVERRIDES=1 suppresses all -c flags -- for proxies that reject them
-echo ""
-echo "test 15c: CODEX_NO_OVERRIDES=1 suppresses -c overrides"
-stub_out="$(cd "$GIT_RC" && CODEX_NO_OVERRIDES=1 PATH="$STUB_DIR:$PATH" bash "$RUN_CODEX" "hello prompt")"
-assert_not_contains "git: no -c model= when CODEX_NO_OVERRIDES" "$stub_out" "model=gpt-5.4"
-assert_not_contains "git: no -c model_reasoning_effort= when CODEX_NO_OVERRIDES" "$stub_out" "model_reasoning_effort"
-assert_not_contains "git: no -c stream_idle_timeout_ms= when CODEX_NO_OVERRIDES" "$stub_out" "stream_idle_timeout_ms"
-assert_not_contains "git: no project_doc when CODEX_NO_OVERRIDES" "$stub_out" "project_doc"
-# non -c args (exec / --sandbox / prompt) must still be there
-assert_contains "git: exec still present with CODEX_NO_OVERRIDES" "$stub_out" "exec"
-assert_contains "git: --sandbox still present with CODEX_NO_OVERRIDES" "$stub_out" "--sandbox"
-assert_contains "git: prompt still passed with CODEX_NO_OVERRIDES" "$stub_out" "hello prompt"
 
 if [ "$HG_AVAILABLE" -eq 1 ]; then
     # test 16: hg repo -> codex called WITH --skip-git-repo-check positioned


### PR DESCRIPTION
## Problem

The hg dispatch added in #15 uses commands that Mercurial-compatible forks have dropped in favour of bookmarks; upstream Mercurial still ships them but recommends bookmark-based workflows. Two of the four hg arms break or emit deprecation noise on modern-Mercurial deployments, and `detect-branch.sh` hard-codes the traditional named-branch convention so `DEFAULT_BRANCH` substitution is wrong in repos that expose remote-tracking refs.

### Why bookmarks

- Mercurial-compatible forks have removed the legacy `branch`/`branches` subcommands entirely.
- Upstream Mercurial still ships them but recommends bookmark-based workflows for modern usage.
- Using `hg book` / `{activebookmark}` / `present(remote/<name>)` revsets is portable across the full ecosystem.

### Failure matrix

| Script | Broken call | Failure (modern Mercurial) |
|--------|-------------|----------------------------|
| `create-branch.sh` do_hg | legacy `branches` subcommand piped to `grep` | `unknown command 'branches'` on implementations that removed it |
| `create-branch.sh` do_hg | legacy `branch <name>` | `(deprecated. use 'hg bookmark' instead)` deprecation notice |
| `create-branch.sh` do_hg | bare legacy `branch` query | same deprecation |
| `detect-branch.sh` do_hg | echoes `default` unconditionally | hard-codes the traditional named-branch convention; ignores remote-tracking refs exposed as `remote/<name>`, so `DEFAULT_BRANCH` substitution is wrong in modern-Mercurial repos |

`stage-and-commit.sh` (`hg commit -A`) and `detect-vcs.sh` (`hg root`) both work cleanly across all current Mercurial versions -- no change needed.

### Reproduction

In any Mercurial repository on a version or implementation that has removed or deprecated the legacy `branches` subcommand:

```
hg branches -q
# -> unknown command 'branches' (or deprecation warning, depending on version)

hg branch foo
# -> (deprecated. use 'hg bookmark' instead)
```

## Fixes

- **`detect-branch.sh` do_hg**: probe `hg log -r "present(remote/<name>)"` for `master`, `main`, `trunk` in order. `present()` suppresses the "unknown revision" abort so the loop is safe even when no remote-tracking refs exist. Falls back to `default` for repos using the traditional named-branch convention.
- **`create-branch.sh` do_hg**: replaced the legacy named-branch ops with bookmark ops:
  - current branch -> `hg log -r . --template '{activebookmark}\n'`
  - list -> `hg book --template '{bookmark}\n'`
  - create -> `hg book <name>`
  - switch -> `hg update <name>`

  Also handles the active-default-bookmark case: when the repo's default line itself is held by an active bookmark (e.g. `master` or `main` in bookmark-based workflows), do_hg now uses `detect-branch.sh` to resolve the default and only early-returns when the active bookmark is *not* the default. Without this, any active bookmark was treated as a feature branch, which skipped bookmark creation and left work on the default line.
- **`SKILL.md` step 1 / step 9 / step 11**:
  - Step 1 describes the new `DEFAULT_BRANCH` substitution semantics (`remote/master` etc. in modern-Mercurial repos that expose remote-tracking refs, `default` in repos that use the named-branch convention) and updates the hg-override rebase hint so the example becomes `hg rebase -d remote/master` where applicable.
  - Step 9 `DIFF_COMMAND` substitution is now VCS-aware. git keeps its existing `git diff DEFAULT_BRANCH...HEAD` / `git diff` forms. hg gets `hg diff -r 'ancestor(., DEFAULT_BRANCH)'` on iteration 1 and `hg diff` thereafter. At runtime `DEFAULT_BRANCH` resolves via `detect-branch.sh`, so the hg form becomes `hg diff -r 'ancestor(., remote/master)'` in repos with remote-tracking refs -- `ancestor(., remote/master)` is a valid revset as long as `remote/master` resolves.
  - Step 11 mirrors the step-1 rebase hint update.
- **CI**: grep-based lint bans the legacy `branch(es)` subcommands in exec scripts so the deprecated commands cannot be reintroduced. Regex is anchored with `^[^#]*` so explanatory comments (e.g. `# don't use hg branch here`) do not trip the lint.
- **`plugin.json`**: 3.5.0 -> 3.5.1 (patch bump for bug fixes).

## Verification

All four shell test suites pass locally:

```
tests/test-brainstorm-resolve-rules.sh:  10 passed, 0 failed
tests/test-exec-vcs-detect.sh:           8 passed, 0 failed
tests/test-exec-vcs-dispatch.sh:         65 passed, 0 failed
tests/test-planning-resolve-rules.sh:    10 passed, 0 failed
```

`tests/test-exec-vcs-dispatch.sh` gained:
- `remote/master` and `remote/main` detection fixtures for `detect-branch.sh`. Remote-tracking refs are simulated via `[revsetalias]` entries because vanilla hg does not ship a remote-tracking-ref layout out of the box; the patched `do_hg` probes `present(remote/<name>)` which accepts any revset that resolves, so the alias is a faithful stand-in for modern-Mercurial environments that expose such refs natively.
- bookmark-based equivalents of the old named-branch `create-branch.sh` tests, covering four cases: fresh repo (creates bookmark + activates); inactive existing bookmark (`hg update` activates it, working copy unchanged -- verified by comparing revision hash before and after); already-on-a-non-default-bookmark (returns current, does NOT create derived); **active-default-bookmark regression test** (active bookmark *is* the default -- must NOT early-return, still creates the derived bookmark).

Shellcheck clean on all modified shell scripts. CI grep-lint anchored regex verified to pass on current exec scripts and to trip on a planted `hg branch foo` regression.

## Migration notes for downstream forks

Downstream forks that locally patched `do_hg` can drop those patches once this lands -- the same upstream code runs across the modern-Mercurial ecosystem without modification.

## Scope notes

The `CODEX_NO_OVERRIDES` env-gate for `run-codex.sh` that was in the original brief has been split out to a separate PR stacked on this one. It is orthogonal to the hg work (fixes a corporate-codex-proxy issue, not a Mercurial issue) and introduces a new user-facing env var surface that warrants a minor version bump rather than the patch bump here.

## Deviations from the original brief

- The brief suggested adding remote-ref detection fixtures in `tests/test-exec-vcs-detect.sh`. That file only tests `detect-vcs.sh`; all `detect-branch.sh` tests live in `tests/test-exec-vcs-dispatch.sh`, so the new fixtures went there alongside the existing ones. No functional change from the brief's intent.
- The brief mentioned a "shellcheck rule (or manual-reviewer-checklist item)" to ban the deprecated commands. Shellcheck has no user-extensible rule system, so I added a grep-based CI step instead.
- A dual CI matrix against both traditional-named-branch Mercurial and bookmark-based Mercurial was not added -- this PR sticks to vanilla hg in CI plus the `[revsetalias]` simulation for the remote-ref codepath. Happy to add a dual-install matrix as a follow-up.

## Stretch: jj-friendliness (not implemented)

The `present()` / bookmark-based approach extends naturally to jj (which uses bookmarks as its primary branch-like thing). If `do_jj` is added later, the patterns here are reusable with minimal change.

## Checklist

- [x] Replace `detect-branch.sh` do_hg
- [x] Replace `create-branch.sh` do_hg (incl. active-default-bookmark handling)
- [x] Update `tests/test-exec-vcs-dispatch.sh` for `remote/<name>` detection + bookmark-based dispatch + active-default-bookmark regression
- [x] Update `SKILL.md` hg notes (step 1, step 11)
- [x] Make `SKILL.md` step 9 `DIFF_COMMAND` substitution VCS-aware
- [x] Add banned-command lint in CI (anchored to skip comments)
- [x] Bump `plugin.json` version (patch: 3.5.0 -> 3.5.1)
- [ ] Add dual-install CI matrix (traditional named-branch vs bookmark-based Mercurial) -- follow-up
