### PR TITLE
Add CODEX_NO_OVERRIDES env-gate to run-codex.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,6 +263,13 @@ Configuration via `userConfig` (prompted at plugin install):
 | `finalize_enabled` | `true` | Whether to run the finalize phase (rebase + squash) |
 | `plans_dir` | `docs/plans` | Directory where plan files are located |
 
+Environment variables read by `run-codex.sh`:
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `CODEX_MODEL` | `gpt-5.4` | Model name passed to `codex exec` via `-c model=...` |
+| `CODEX_NO_OVERRIDES` | *(unset)* | When set to the literal value `1`, suppresses all `-c` overrides (`model`, `model_reasoning_effort`, `stream_idle_timeout_ms`, `project_doc`). Useful for codex proxies / wrappers that reject `-c model/provider` overrides. Any other value (including `0`, `false`, empty) leaves the overrides on. |
+
 ### release-tools
 
 Release workflow tools for creating versioned releases with auto-generated notes.

--- a/plugins/planning/.claude-plugin/plugin.json
+++ b/plugins/planning/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "planning",
   "description": "Structured implementation planning, interactive annotation review, and autonomous plan execution",
-  "version": "3.5.1",
+  "version": "3.6.0",
   "author": {
     "name": "Umputun"
   },

--- a/plugins/planning/skills/exec/scripts/run-codex.sh
+++ b/plugins/planning/skills/exec/scripts/run-codex.sh
@@ -21,13 +21,22 @@ vcs=$(bash "$SCRIPT_DIR/detect-vcs.sh")
 # 'exec' (before --sandbox) as an exec-level option
 args=("exec")
 [ "$vcs" = "hg" ] && args+=("--skip-git-repo-check")
-args+=(
-    "--sandbox" "read-only"
-    "-c" "model=${CODEX_MODEL:-gpt-5.4}"
-    "-c" "model_reasoning_effort=high"
-    "-c" "stream_idle_timeout_ms=3600000"
-    "-c" "project_doc=$HOME/.claude/CLAUDE.md"
-    "-c" "project_doc=./CLAUDE.md"
-)
+args+=("--sandbox" "read-only")
+
+# -c overrides switch provider routing in a way some corporate codex
+# proxies / wrappers reject (e.g. "Error: Model provider 'responses' not
+# found"). Set CODEX_NO_OVERRIDES=1 to skip the overrides and fall
+# through to the proxy's defaults. Only the literal value `1` activates
+# suppression -- any other value (including `0`, `false`, empty) keeps
+# the overrides on, matching the documented "set to 1 to enable" semantic.
+if [ "${CODEX_NO_OVERRIDES:-}" != 1 ]; then
+    args+=(
+        "-c" "model=${CODEX_MODEL:-gpt-5.4}"
+        "-c" "model_reasoning_effort=high"
+        "-c" "stream_idle_timeout_ms=3600000"
+        "-c" "project_doc=$HOME/.claude/CLAUDE.md"
+        "-c" "project_doc=./CLAUDE.md"
+    )
+fi
 
 codex "${args[@]}" "$prompt"

--- a/tests/test-exec-vcs-dispatch.sh
+++ b/tests/test-exec-vcs-dispatch.sh
@@ -520,6 +520,37 @@ stub_out="$(cd "$GIT_RC" && CODEX_MODEL=gpt-5.5 PATH="$STUB_DIR:$PATH" bash "$RU
 assert_contains "git: CODEX_MODEL env var overrides model" "$stub_out" "model=gpt-5.5"
 assert_not_contains "git: default model not used when override set" "$stub_out" "model=gpt-5.4"
 
+# test 15c: CODEX_NO_OVERRIDES=1 suppresses all -c flags -- for proxies that reject them
+echo ""
+echo "test 15c: CODEX_NO_OVERRIDES=1 suppresses -c overrides"
+stub_out="$(cd "$GIT_RC" && CODEX_NO_OVERRIDES=1 PATH="$STUB_DIR:$PATH" bash "$RUN_CODEX" "hello prompt")"
+assert_not_contains "git: no -c model= when CODEX_NO_OVERRIDES=1" "$stub_out" "model=gpt-5.4"
+assert_not_contains "git: no -c model_reasoning_effort= when CODEX_NO_OVERRIDES=1" "$stub_out" "model_reasoning_effort"
+assert_not_contains "git: no -c stream_idle_timeout_ms= when CODEX_NO_OVERRIDES=1" "$stub_out" "stream_idle_timeout_ms"
+assert_not_contains "git: no project_doc when CODEX_NO_OVERRIDES=1" "$stub_out" "project_doc"
+# non -c args (exec / --sandbox / prompt) must still be there
+assert_contains "git: exec still present with CODEX_NO_OVERRIDES=1" "$stub_out" "exec"
+assert_contains "git: --sandbox still present with CODEX_NO_OVERRIDES=1" "$stub_out" "--sandbox"
+assert_contains "git: prompt still passed with CODEX_NO_OVERRIDES=1" "$stub_out" "hello prompt"
+
+# test 15d: only the literal "1" activates suppression -- other values must NOT silently turn it on.
+# guards against the "set to 1 to enable" semantic surprise where someone tries =0 to disable
+# and accidentally enables it.
+echo ""
+echo "test 15d: CODEX_NO_OVERRIDES=0 does NOT activate suppression"
+stub_out="$(cd "$GIT_RC" && CODEX_NO_OVERRIDES=0 PATH="$STUB_DIR:$PATH" bash "$RUN_CODEX" "hello prompt")"
+assert_contains "git: -c model= present when CODEX_NO_OVERRIDES=0" "$stub_out" "model=gpt-5.4"
+
+echo ""
+echo "test 15e: CODEX_NO_OVERRIDES=false does NOT activate suppression"
+stub_out="$(cd "$GIT_RC" && CODEX_NO_OVERRIDES=false PATH="$STUB_DIR:$PATH" bash "$RUN_CODEX" "hello prompt")"
+assert_contains "git: -c model= present when CODEX_NO_OVERRIDES=false" "$stub_out" "model=gpt-5.4"
+
+echo ""
+echo "test 15f: CODEX_NO_OVERRIDES=no does NOT activate suppression"
+stub_out="$(cd "$GIT_RC" && CODEX_NO_OVERRIDES=no PATH="$STUB_DIR:$PATH" bash "$RUN_CODEX" "hello prompt")"
+assert_contains "git: -c model= present when CODEX_NO_OVERRIDES=no" "$stub_out" "model=gpt-5.4"
+
 if [ "$HG_AVAILABLE" -eq 1 ]; then
     # test 16: hg repo -> codex called WITH --skip-git-repo-check positioned
     # right after 'exec' (before --sandbox)


### PR DESCRIPTION
Stacked on #19 (hg dispatch modernisation). Merges cleanly after #19 lands.

## Problem

Some corporate codex proxies / wrappers reject `-c model/provider` overrides on `codex exec` invocations -- the override switches provider routing in a way the proxy refuses, returning `Error: Model provider 'responses' not found`. This affects all `-c` invocations, not just ones that touch the model. The bare `codex exec --skip-git-repo-check --sandbox read-only "<prompt>"` form works fine on the same proxy.

This is orthogonal to the hg work in #19 -- it's a deployment compatibility issue with codex itself, not a Mercurial issue. Splitting it out keeps the patch / minor distinction clean.

## Reproduction

```
codex exec --skip-git-repo-check --sandbox read-only -c "model=gpt-5.4" "say hi"
# against a proxy that rejects -c overrides:
# -> Error: Model provider 'responses' not found

codex exec --skip-git-repo-check --sandbox read-only "say hi"
# works
```

## Fix

Gate the `-c` override block on `CODEX_NO_OVERRIDES`. Downstream forks set `CODEX_NO_OVERRIDES=1` once and run upstream verbatim; zero cost for upstream users who don't set it.

```bash
if [ "${CODEX_NO_OVERRIDES:-}" != 1 ]; then
    args+=(
        "-c" "model=${CODEX_MODEL:-gpt-5.4}"
        "-c" "model_reasoning_effort=high"
        "-c" "stream_idle_timeout_ms=3600000"
        "-c" "project_doc=$HOME/.claude/CLAUDE.md"
        "-c" "project_doc=./CLAUDE.md"
    )
fi
```

Only the literal value `1` activates suppression. Any other value (including `0`, `false`, `no`, empty) leaves the overrides on. This matches the documented "set to 1 to enable" semantic and avoids the surprise where `=0` would have been treated as truthy under a `[ -z ... ]` check.

## Verification

```
tests/test-exec-vcs-dispatch.sh: 75 passed, 0 failed
```

New tests cover:
- **15c** `CODEX_NO_OVERRIDES=1` suppresses all four `-c` flag groups (`model`, `model_reasoning_effort`, `stream_idle_timeout_ms`, `project_doc`); non-`-c` args (`exec`, `--sandbox`, prompt) still go through.
- **15d/15e/15f** `CODEX_NO_OVERRIDES=0`, `=false`, `=no` all leave the `-c model=...` override on. Guards against the truthy/falsy-string surprise.

Shellcheck clean.

## Documentation

README gets a new "Environment variables read by `run-codex.sh`" section documenting both:
- `CODEX_NO_OVERRIDES` -- the new env-gate
- `CODEX_MODEL` -- existing knob from #15 that was previously undocumented

Per CLAUDE.md ("README must be kept up to date on new config").

## Version bump

`plugins/planning/.claude-plugin/plugin.json`: 3.5.1 -> 3.6.0.

Per the repo's semver convention (patch for bug fixes, minor for new components / surfaces), introducing a new user-facing env var is a minor bump rather than patch.

## Stack

- #19: hg dispatch modernisation (patch: 3.5.0 -> 3.5.1)
- this PR: codex env-gate (minor: 3.5.1 -> 3.6.0)

If #19 lands first, this rebases trivially onto master (no overlap with hg files). If they land in either order, the version bumps compose cleanly.
