### PR TITLE
chore(ask-codex): bump default model to gpt-5.5

### DIFF
--- a/plugins/thinking-tools/skills/ask-codex/SKILL.md
+++ b/plugins/thinking-tools/skills/ask-codex/SKILL.md
@@ -155,7 +155,7 @@ Use "approve" only if you cannot support any substantive finding.
 Run codex in background (it takes 2-5 minutes for complex analysis):
 
 ```bash
-codex exec -m gpt-5.4 \
+codex exec -m gpt-5.5 \
   --sandbox read-only \
   -c model_reasoning_effort="high" \
   -c stream_idle_timeout_ms=600000 \
@@ -172,7 +172,7 @@ codex exec -m gpt-5.4 \
 
 **Flags:**
 - `--sandbox read-only` — codex can read all project files but cannot modify anything
-- `-m gpt-5.4` — latest model (adjust as newer versions become available)
+- `-m gpt-5.5` — latest model (adjust as newer versions become available)
 - `model_reasoning_effort="high"` — maximum reasoning depth
 - `project_doc` — passes CLAUDE.md as project context (both global and local if present)
 


### PR DESCRIPTION
## Summary

Bump the default Codex model from `gpt-5.4` to `gpt-5.5` in `plugins/thinking-tools/skills/ask-codex/SKILL.md`. Two occurrences updated: the example invocation in Step 4 and the corresponding line in the Flags reference.

The skill already notes that the model should be adjusted as newer versions become available; this brings the default in line with the current generally-available Codex model.

## Test plan
- [x] `git diff` confirms only the two intended lines changed.
- [x] Run `codex exec -m gpt-5.5 ...` locally to confirm the model is reachable on your account (already verified on mine).