### PR TITLE
feat(workflow): clarify destination semantics in learn skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -325,13 +325,13 @@ Session workflow helpers for knowledge capture, confusion handling, course corre
 
 | Component | Trigger | Description |
 |-----------|---------|-------------|
-| skill | `/workflow:learn` | Capture strategic project knowledge to local CLAUDE.md |
+| skill | `/workflow:learn` | Capture strategic project knowledge to CLAUDE.md (routes to CLAUDE.local.md when that file is present) |
 | skill | `/workflow:clarify` | Investigate and explain user confusion, determine if real issue exists |
 | skill | `/workflow:wrong` | Reset and re-evaluate when current approach isn't working |
 | skill | `/workflow:md-copy` | Format final answer as markdown and copy to clipboard |
 | skill | `/workflow:txt-copy` | Copy generated text content to clipboard |
 
-**learn** — reviews conversation history, extracts strategic project knowledge (architecture patterns, conventions, operational insights), and saves selected items to local CLAUDE.md. Uses granular selection via AskUserQuestion so the user picks exactly what to keep.
+**learn** — reviews conversation history, extracts strategic project knowledge (architecture patterns, conventions, operational insights), and saves selected items to the project's `CLAUDE.md`. When `CLAUDE.local.md` is present, per-developer / per-checkout discoveries (machine-specific tooling, environment quirks) are routed there instead. Defers to any project-defined memory-placement guidance documented in `CLAUDE.md` or `.claude/rules/`. Uses granular selection via AskUserQuestion so the user picks exactly what to keep.
 
 **clarify** — activates on confusion signals ("I don't understand", "why is this happening", etc.). Investigates the actual codebase to determine whether the confusion stems from a misunderstanding or a real issue. If real, proceeds to plan mode for a fix.
 

--- a/plugins/workflow/.claude-plugin/plugin.json
+++ b/plugins/workflow/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "workflow",
   "description": "Session workflow helpers - knowledge capture, confusion handling, course correction, clipboard copy",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "author": {
     "name": "Umputun"
   },

--- a/plugins/workflow/skills/learn/SKILL.md
+++ b/plugins/workflow/skills/learn/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: learn
-description: Update local CLAUDE.md with strategic knowledge discovered during this session. Use when user says "learn", "save knowledge", "update claude.md", "capture learnings", or at end of significant work sessions. Also used by commit skill for pre-commit knowledge capture.
+description: Update the project's CLAUDE.md with strategic knowledge discovered during this session — or CLAUDE.local.md when the discovery is per-developer/per-checkout and that file already exists. Use when user says "learn", "save knowledge", "update claude.md", "capture learnings", or at end of significant work sessions. Defers to any project-defined memory-placement guidance instead of overriding it. Also used by commit skill for pre-commit knowledge capture.
 allowed-tools: Read, Edit, AskUserQuestion
 ---
 
 # Learn
 
-Review the current conversation history and identify strategic, reusable project knowledge that should be captured in the local CLAUDE.md file.
+Review the current conversation history and identify strategic, reusable project knowledge that should be captured in the project's `CLAUDE.md`. When the project has opted into the convention by creating `CLAUDE.local.md`, route genuinely personal or environment-specific discoveries there instead.
 
 ## Analysis Process
 
@@ -31,7 +31,20 @@ Review the current conversation history and identify strategic, reusable project
    - Build and deployment processes
    - Operational knowledge (debugging, DevOps)
 
-## What Qualifies for Local CLAUDE.md
+## Destinations
+
+This skill writes to one of two files in the project root:
+
+- **`CLAUDE.md`** (committed, team-shared) — the default destination. Use for architecture, conventions, integration patterns, and any other knowledge useful to the whole team.
+- **`CLAUDE.local.md`** (gitignored personal overrides) — used only when **both** conditions hold:
+  1. `CLAUDE.local.md` already exists in the project (the project has opted into the three-tier memory convention).
+  2. The discovery is genuinely per-developer or per-checkout — references user-home paths, machine-specific tool configuration, per-developer credentials, or phrasing like "in this environment" / "on this checkout".
+
+This skill never writes to the user's global `~/.claude/CLAUDE.md` — only reads it to avoid duplicating cross-project knowledge.
+
+**Default for ambiguous cases: `CLAUDE.md`.** Leaking personal config into a committed file is a loud error that reviewers catch quickly; hiding project-wide knowledge in a gitignored personal file is a silent error that rots over time.
+
+## What Qualifies
 
 **INCLUDE** - Strategic discoveries from this session:
 - Architectural patterns uncovered while working
@@ -70,67 +83,74 @@ Ask yourself for each discovery:
 
 ## Workflow
 
-### 1. Check Existing Local CLAUDE.md
-First, check if local CLAUDE.md exists and read its current content to avoid duplication.
+### 1. Check for Existing Memory-Placement Guidance
+Before applying the routing rules below, scan the project's root `CLAUDE.md`, any `.claude/rules/*.md` files, and the user's global `~/.claude/CLAUDE.md` for documented memory-placement guidance — for example, a placement decision tree, an instruction to use a project-specific triage command, or specific destinations beyond `CLAUDE.md` / `CLAUDE.local.md`. If such guidance exists, defer to it: follow the documented workflow or place each discovery according to its rules instead of using this skill's defaults. The remaining steps apply only when no such guidance is found.
 
-### 2. Early Exit if Nothing Found
+### 2. Check Existing Memory Content
+Read the current content of `CLAUDE.md` (and `CLAUDE.local.md` if present) to avoid duplication.
+
+### 3. Early Exit if Nothing Found
 If no new strategic knowledge was discovered during this session:
 - Report "no new strategic knowledge to capture"
 - Do NOT use AskUserQuestion tool
 - End the skill execution
 
-### 3. New Knowledge to Add
-Present discovered knowledge formatted for local CLAUDE.md:
+### 4. Classify Each Discovery
+For each discovery, determine its destination per the [Destinations](#destinations) rules: default to `CLAUDE.md`, and route to `CLAUDE.local.md` only when both file-exists and personal-content criteria are met.
+
+### 5. New Knowledge to Add
+Present discovered knowledge formatted for the chosen destination, tagging each block with its inferred file:
 ```markdown
-## [Section Name]
+## [Section Name] → CLAUDE.md
 - Discovery 1
 - Discovery 2
 ```
 
-### 4. User Confirmation with AskUserQuestion Tool
+### 6. User Confirmation with AskUserQuestion Tool
 
 **CRITICAL**: Use AskUserQuestion tool for granular selection of what to save.
 
 Build options dynamically based on discoveries:
-- First option: "All knowledge" - save everything discovered
+- First option: "All knowledge" - save everything to its inferred destination
 - Last option before custom: "None" - skip saving entirely
-- Middle options: Individual knowledge items (up to 2-3 most significant)
+- Middle options: Individual knowledge items (up to 2-3 most significant), each labelled with its inferred destination
 - User can always type custom selection via "Other"
 
-Example with 3 discoveries:
+Example with 3 discoveries (2 project, 1 personal):
 ```
-question: "Which knowledge should I save to local CLAUDE.md?"
+question: "Which knowledge should I save?"
 options:
   - label: "All (3 items)"
-    description: "Save all discovered patterns"
-  - label: "Testing pattern"
-    description: "Table-driven tests with shared fixtures"
-  - label: "Config approach"
-    description: "Environment-based configuration loading"
+    description: "Save all discovered patterns to their inferred destinations"
+  - label: "Service discovery pattern → CLAUDE.md"
+    description: "Project-wide convention for how modules find each other"
+  - label: "Local toolchain variant → CLAUDE.local.md"
+    description: "Per-checkout build runner override (only relevant on this machine)"
   - label: "None"
     description: "Skip saving, nothing worth keeping"
 ```
 
 Example with 1 discovery:
 ```
-question: "Save this knowledge to local CLAUDE.md?"
+question: "Save this knowledge?"
 options:
-  - label: "Yes"
+  - label: "Yes → CLAUDE.md"
     description: "Save: [brief description of the discovery]"
   - label: "No"
     description: "Skip saving"
 ```
 
 After user selection:
-- "All" -> save everything
+- "All" -> save everything to inferred destinations
 - "None" -> end without saving
-- Specific item -> save only that item
-- "Other" -> user types custom selection (comma-separated items or partial list)
+- Specific item -> save only that item, to the inferred destination shown in the label
+- "Other" -> user types custom selection (comma-separated items or partial list); accept overrides of the inferred destination if the user names a different file
 
 ## Important Guidelines
 - Only capture genuinely new discoveries from this session
-- Don't duplicate existing local or global CLAUDE.md content
+- Don't duplicate existing `CLAUDE.md`, `CLAUDE.local.md`, or `~/.claude/CLAUDE.md` content
 - Focus on patterns observed, not specific code written
 - Keep descriptions concise and actionable
 - MUST use AskUserQuestion tool for confirmation (not plain text questions)
 - If no knowledge found, exit early without asking
+- **Defer to project- or user-level memory-placement guidance discovered in step 1** — do not override existing conventions with this skill's defaults


### PR DESCRIPTION
## Summary

Resolves a long-standing ambiguity in `/workflow:learn` about where it writes when a project follows Claude Code's full memory tiering (user-global `~/.claude/CLAUDE.md`, project `CLAUDE.md`, and per-developer `CLAUDE.local.md`).

### The confusion

The previous skill body and frontmatter described the destination as **"local CLAUDE.md"**. In the [official memory docs](https://code.claude.com/docs/en/memory), *"local"* refers specifically to `CLAUDE.local.md` — the gitignored per-developer overrides file. But the skill's `INCLUDE` list and decision criteria describe **project-wide, team-shared knowledge** (architectural patterns, conventions, integration patterns; *"Does this represent a project-wide convention?"*).

The literal wording said one destination; the content described another. In projects that have both `CLAUDE.md` and `CLAUDE.local.md`, this caused team-shared knowledge to silently land in personal overrides where teammates never see it — and the agent had to pick a side based on which interpretation it privileged.

### What this PR changes

**1. Renames "local CLAUDE.md" → `CLAUDE.md`** throughout the skill body, the frontmatter `description`, and the README entries — aligning wording with the [official memory conventions](https://code.claude.com/docs/en/memory):

- `CLAUDE.md` = project memory (committed, team-shared)
- `CLAUDE.local.md` = local memory (gitignored, per-developer)
- `~/.claude/CLAUDE.md` = user memory (global)

**2. Adds opt-in routing to `CLAUDE.local.md`** for genuinely personal / per-checkout discoveries (machine-specific tooling, environment quirks, user-home paths, per-developer credentials). Gated on **both** conditions:

- `CLAUDE.local.md` already exists in the project (the project has opted into the three-tier convention).
- The discovery has clear personal-environment markers, not project-wide intent.

For ambiguous cases the skill defaults to `CLAUDE.md`. The asymmetric-error-cost rationale is in the SKILL.md body: leaking personal config into a committed file is a loud error reviewers catch quickly; hiding project-wide knowledge in a gitignored personal file is a silent error that rots over time. So when uncertain, fail loud.

**3. Adds a deference clause as the first workflow step.** When the project's `CLAUDE.md`, any `.claude/rules/*.md`, or the user's `~/.claude/CLAUDE.md` documents a memory-placement workflow (placement decision trees, project-specific triage commands, destinations beyond `CLAUDE.md` / `CLAUDE.local.md`), the skill defers to that guidance instead of imposing its own defaults. This makes the skill composable with project-specific memory architectures rather than overriding them.

**4. Surfaces inferred destinations in the per-item `AskUserQuestion` prompt** (`Service discovery pattern → CLAUDE.md`, `Local toolchain variant → CLAUDE.local.md`), so users can see and override the routing per discovery.

**5. Updates the frontmatter `description`** to reflect the new behavior. Trigger phrases (`"learn"`, `"save knowledge"`, `"update claude.md"`, `"capture learnings"`) are preserved — activation patterns don't change.

**6. Bumps the workflow plugin to `1.1.0`** and updates the two README entries (table row and learn-skill paragraph). Minor-bump rationale: behavior change for projects with both `CLAUDE.md` and `CLAUDE.local.md` (new routing rule) — happy to downgrade to `1.0.1` if you'd rather treat this purely as a clarification.