### PR TITLE
fix(workflow): align learn skill terminology with official memory docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -325,13 +325,13 @@ Session workflow helpers for knowledge capture, confusion handling, course corre
 
 | Component | Trigger | Description |
 |-----------|---------|-------------|
-| skill | `/workflow:learn` | Capture strategic project knowledge to local CLAUDE.md |
+| skill | `/workflow:learn` | Capture strategic project knowledge to project CLAUDE.md |
 | skill | `/workflow:clarify` | Investigate and explain user confusion, determine if real issue exists |
 | skill | `/workflow:wrong` | Reset and re-evaluate when current approach isn't working |
 | skill | `/workflow:md-copy` | Format final answer as markdown and copy to clipboard |
 | skill | `/workflow:txt-copy` | Copy generated text content to clipboard |
 
-**learn** — reviews conversation history, extracts strategic project knowledge (architecture patterns, conventions, operational insights), and saves selected items to local CLAUDE.md. Uses granular selection via AskUserQuestion so the user picks exactly what to keep.
+**learn** — reviews conversation history, extracts strategic project knowledge (architecture patterns, conventions, operational insights), and saves selected items to project CLAUDE.md. Uses granular selection via AskUserQuestion so the user picks exactly what to keep.
 
 **clarify** — activates on confusion signals ("I don't understand", "why is this happening", etc.). Investigates the actual codebase to determine whether the confusion stems from a misunderstanding or a real issue. If real, proceeds to plan mode for a fix.
 

--- a/plugins/workflow/.claude-plugin/plugin.json
+++ b/plugins/workflow/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "workflow",
   "description": "Session workflow helpers - knowledge capture, confusion handling, course correction, clipboard copy",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "author": {
     "name": "Umputun"
   },

--- a/plugins/workflow/skills/learn/SKILL.md
+++ b/plugins/workflow/skills/learn/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: learn
-description: Update local CLAUDE.md with strategic knowledge discovered during this session. Use when user says "learn", "save knowledge", "update claude.md", "capture learnings", or at end of significant work sessions. Also used by commit skill for pre-commit knowledge capture.
+description: Update project CLAUDE.md with strategic knowledge discovered during this session. Use when user says "learn", "save knowledge", "update claude.md", "capture learnings", or at end of significant work sessions. Also used by commit skill for pre-commit knowledge capture.
 allowed-tools: Read, Edit, AskUserQuestion
 ---
 
 # Learn
 
-Review the current conversation history and identify strategic, reusable project knowledge that should be captured in the local CLAUDE.md file.
+Review the current conversation history and identify strategic, reusable project knowledge that should be captured in the project CLAUDE.md file.
 
 ## Analysis Process
 
@@ -31,7 +31,7 @@ Review the current conversation history and identify strategic, reusable project
    - Build and deployment processes
    - Operational knowledge (debugging, DevOps)
 
-## What Qualifies for Local CLAUDE.md
+## What Qualifies for Project CLAUDE.md
 
 **INCLUDE** - Strategic discoveries from this session:
 - Architectural patterns uncovered while working
@@ -70,8 +70,8 @@ Ask yourself for each discovery:
 
 ## Workflow
 
-### 1. Check Existing Local CLAUDE.md
-First, check if local CLAUDE.md exists and read its current content to avoid duplication.
+### 1. Check Existing Project CLAUDE.md
+First, check if project CLAUDE.md exists and read its current content to avoid duplication.
 
 ### 2. Early Exit if Nothing Found
 If no new strategic knowledge was discovered during this session:
@@ -80,7 +80,7 @@ If no new strategic knowledge was discovered during this session:
 - End the skill execution
 
 ### 3. New Knowledge to Add
-Present discovered knowledge formatted for local CLAUDE.md:
+Present discovered knowledge formatted for project CLAUDE.md:
 ```markdown
 ## [Section Name]
 - Discovery 1
@@ -99,7 +99,7 @@ Build options dynamically based on discoveries:
 
 Example with 3 discoveries:
 ```
-question: "Which knowledge should I save to local CLAUDE.md?"
+question: "Which knowledge should I save to project CLAUDE.md?"
 options:
   - label: "All (3 items)"
     description: "Save all discovered patterns"
@@ -113,7 +113,7 @@ options:
 
 Example with 1 discovery:
 ```
-question: "Save this knowledge to local CLAUDE.md?"
+question: "Save this knowledge to project CLAUDE.md?"
 options:
   - label: "Yes"
     description: "Save: [brief description of the discovery]"
@@ -129,7 +129,7 @@ After user selection:
 
 ## Important Guidelines
 - Only capture genuinely new discoveries from this session
-- Don't duplicate existing local or global CLAUDE.md content
+- Don't duplicate existing project or user CLAUDE.md content
 - Focus on patterns observed, not specific code written
 - Keep descriptions concise and actionable
 - MUST use AskUserQuestion tool for confirmation (not plain text questions)


### PR DESCRIPTION
## Summary

Per-feedback split of #23 (closed). This PR contains the **rename-only** half: removing the ambiguous "local CLAUDE.md" wording from `/workflow:learn` and aligning it with the [official Claude Code memory docs](https://code.claude.com/docs/en/memory).

### What this fixes

The previous skill body and frontmatter described the destination as **"local CLAUDE.md"**. In the official memory tiering, "local" specifically means `CLAUDE.local.md` (gitignored per-developer overrides). But the skill's `INCLUDE` list and decision criteria describe team-shared project knowledge (architectural patterns, conventions, integration patterns; *"Does this represent a project-wide convention?"*).

The wording and the content disagreed. In projects that have both `CLAUDE.md` and `CLAUDE.local.md`, this caused team-shared knowledge to silently land in personal overrides where teammates never see it.

### What this PR does

- Renames every "local CLAUDE.md" / "Local CLAUDE.md" reference to "CLAUDE.md" — 9 occurrences in `SKILL.md` (frontmatter description + body), 2 in `README.md`.
- Rewrites the one "local or global CLAUDE.md" line in the guidelines to "CLAUDE.md or `~/.claude/CLAUDE.md`" — matches the official names for *project memory* and *user memory* respectively.
- Bumps the workflow plugin to `1.0.1` (patch — pure terminology, no behavior change).

### What this PR does NOT do

No new sections, no new workflow steps, no destination routing, no `AskUserQuestion` changes, no frontmatter restructure. Trigger phrases (`"learn"`, `"save knowledge"`, `"update claude.md"`, `"capture learnings"`) and `allowed-tools` are unchanged.

### Companion PR

The routing + deference design (the contentious half of #23) will come as a separate stacked PR — `learn-skill-routing-and-deference` — with the heuristic-overfitting and "Other"-blast-radius concerns from #23 surfaced in that PR's body for discussion.