### PR TITLE
feat(workflow): add CLAUDE.local.md routing and memory-placement deference

### DIFF
--- a/README.md
+++ b/README.md
@@ -325,13 +325,13 @@ Session workflow helpers for knowledge capture, confusion handling, course corre
 
 | Component | Trigger | Description |
 |-----------|---------|-------------|
-| skill | `/workflow:learn` | Capture strategic project knowledge to project CLAUDE.md |
+| skill | `/workflow:learn` | Capture strategic project knowledge to project CLAUDE.md (routes to CLAUDE.local.md when that file is present) |
 | skill | `/workflow:clarify` | Investigate and explain user confusion, determine if real issue exists |
 | skill | `/workflow:wrong` | Reset and re-evaluate when current approach isn't working |
 | skill | `/workflow:md-copy` | Format final answer as markdown and copy to clipboard |
 | skill | `/workflow:txt-copy` | Copy generated text content to clipboard |
 
-**learn** — reviews conversation history, extracts strategic project knowledge (architecture patterns, conventions, operational insights), and saves selected items to project CLAUDE.md. Uses granular selection via AskUserQuestion so the user picks exactly what to keep.
+**learn** — reviews conversation history, extracts strategic project knowledge (architecture patterns, conventions, operational insights), and saves selected items to the project CLAUDE.md. When `CLAUDE.local.md` is present, per-developer / per-checkout discoveries (machine-specific tooling, environment quirks) are routed there instead. Defers to any project-defined memory-placement guidance documented in `CLAUDE.md` or `.claude/rules/`. Uses granular selection via AskUserQuestion so the user picks exactly what to keep.
 
 **clarify** — activates on confusion signals ("I don't understand", "why is this happening", etc.). Investigates the actual codebase to determine whether the confusion stems from a misunderstanding or a real issue. If real, proceeds to plan mode for a fix.
 

--- a/README.md
+++ b/README.md
@@ -325,7 +325,7 @@ Session workflow helpers for knowledge capture, confusion handling, course corre
 
 | Component | Trigger | Description |
 |-----------|---------|-------------|
-| skill | `/workflow:learn` | Capture strategic project knowledge to project CLAUDE.md (routes to CLAUDE.local.md when that file is present) |
+| skill | `/workflow:learn` | Capture strategic project knowledge to project CLAUDE.md (routes per-developer / per-checkout discoveries to CLAUDE.local.md when that file is present) |
 | skill | `/workflow:clarify` | Investigate and explain user confusion, determine if real issue exists |
 | skill | `/workflow:wrong` | Reset and re-evaluate when current approach isn't working |
 | skill | `/workflow:md-copy` | Format final answer as markdown and copy to clipboard |

--- a/plugins/workflow/.claude-plugin/plugin.json
+++ b/plugins/workflow/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "workflow",
   "description": "Session workflow helpers - knowledge capture, confusion handling, course correction, clipboard copy",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "author": {
     "name": "Umputun"
   },

--- a/plugins/workflow/skills/learn/SKILL.md
+++ b/plugins/workflow/skills/learn/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: learn
-description: Update project CLAUDE.md with strategic knowledge discovered during this session. Use when user says "learn", "save knowledge", "update claude.md", "capture learnings", or at end of significant work sessions. Also used by commit skill for pre-commit knowledge capture.
+description: Update project CLAUDE.md with strategic knowledge discovered during this session — or CLAUDE.local.md when the discovery is per-developer/per-checkout and that file already exists. Defers to any project-defined memory-placement guidance instead of overriding it. Use when user says "learn", "save knowledge", "update claude.md", "capture learnings", or at end of significant work sessions. Also used by commit skill for pre-commit knowledge capture.
 allowed-tools: Read, Edit, AskUserQuestion
 ---
 
 # Learn
 
-Review the current conversation history and identify strategic, reusable project knowledge that should be captured in the project CLAUDE.md file.
+Review the current conversation history and identify strategic, reusable project knowledge that should be captured in the project CLAUDE.md file. When the project has opted into Claude Code's three-tier memory convention by creating `CLAUDE.local.md`, route genuinely personal or environment-specific discoveries there instead.
 
 ## Analysis Process
 
@@ -31,7 +31,22 @@ Review the current conversation history and identify strategic, reusable project
    - Build and deployment processes
    - Operational knowledge (debugging, DevOps)
 
-## What Qualifies for Project CLAUDE.md
+## Destinations
+
+This skill writes to one of two files in the project root:
+
+- **`CLAUDE.md`** (project memory, committed, team-shared) — the default destination. Use for architecture, conventions, integration patterns, and any other knowledge useful to the whole team.
+- **`CLAUDE.local.md`** (local memory, gitignored personal overrides) — used only when **both** conditions hold:
+  1. `CLAUDE.local.md` already exists in the project (the project has opted into the three-tier memory convention).
+  2. The discovery describes per-developer / per-checkout state — not just *mentions* something personal, but the knowledge itself is meaningful only to the current developer on this machine. Examples: a tool-loading workaround that depends on this developer's interpreter / runtime setup, a personal alias, a per-checkout env override.
+
+  **Counter-example:** *"We keep credentials in `~/.aws/credentials`"* mentions a user-home path but describes a team-wide convention — the path is illustrative, not per-developer state. Such notes belong in project CLAUDE.md. When in doubt about whether a discovery is genuinely personal, default to project CLAUDE.md.
+
+This skill never writes to the user's global `~/.claude/CLAUDE.md` (user memory) — only reads it to avoid duplicating cross-project knowledge.
+
+**Default for ambiguous cases: project CLAUDE.md.** Leaking personal config into a committed file is a loud error that reviewers catch quickly; hiding project-wide knowledge in a gitignored personal file is a silent error that rots over time.
+
+## What Qualifies
 
 **INCLUDE** - Strategic discoveries from this session:
 - Architectural patterns uncovered while working
@@ -70,67 +85,74 @@ Ask yourself for each discovery:
 
 ## Workflow
 
-### 1. Check Existing Project CLAUDE.md
-First, check if project CLAUDE.md exists and read its current content to avoid duplication.
+### 1. Check for Existing Memory-Placement Guidance
+Before applying the routing rules below, scan the project's root `CLAUDE.md`, any `.claude/rules/*.md` files, and the user's global `~/.claude/CLAUDE.md` for documented memory-placement guidance — for example, a placement decision tree, an instruction to use a project-specific triage command, or specific destinations beyond `CLAUDE.md` / `CLAUDE.local.md`. If such guidance exists, defer to it: follow the documented workflow or place each discovery according to its rules instead of using this skill's defaults. The remaining steps apply only when no such guidance is found.
 
-### 2. Early Exit if Nothing Found
+### 2. Check Existing Memory Content
+Read the current content of project `CLAUDE.md` (and `CLAUDE.local.md` if present) to avoid duplication.
+
+### 3. Early Exit if Nothing Found
 If no new strategic knowledge was discovered during this session:
 - Report "no new strategic knowledge to capture"
 - Do NOT use AskUserQuestion tool
 - End the skill execution
 
-### 3. New Knowledge to Add
-Present discovered knowledge formatted for project CLAUDE.md:
+### 4. Classify Each Discovery
+For each discovery, determine its destination per the [Destinations](#destinations) rules: default to project CLAUDE.md, and route to `CLAUDE.local.md` only when both file-exists and personal-content criteria are met (and the counter-example caveat doesn't apply).
+
+### 5. New Knowledge to Add
+Present discovered knowledge formatted for the chosen destination, tagging each block with its inferred file:
 ```markdown
-## [Section Name]
+## [Section Name] → project CLAUDE.md
 - Discovery 1
 - Discovery 2
 ```
 
-### 4. User Confirmation with AskUserQuestion Tool
+### 6. User Confirmation with AskUserQuestion Tool
 
 **CRITICAL**: Use AskUserQuestion tool for granular selection of what to save.
 
 Build options dynamically based on discoveries:
-- First option: "All knowledge" - save everything discovered
+- First option: "All knowledge" - save everything to its inferred destination
 - Last option before custom: "None" - skip saving entirely
-- Middle options: Individual knowledge items (up to 2-3 most significant)
+- Middle options: Individual knowledge items (up to 2-3 most significant), each labelled with its inferred destination
 - User can always type custom selection via "Other"
 
-Example with 3 discoveries:
+Example with 3 discoveries (2 project, 1 personal):
 ```
-question: "Which knowledge should I save to project CLAUDE.md?"
+question: "Which knowledge should I save?"
 options:
   - label: "All (3 items)"
-    description: "Save all discovered patterns"
-  - label: "Testing pattern"
-    description: "Table-driven tests with shared fixtures"
-  - label: "Config approach"
-    description: "Environment-based configuration loading"
+    description: "Save all discovered patterns to their inferred destinations"
+  - label: "Service discovery pattern → project CLAUDE.md"
+    description: "Project-wide convention for how modules find each other"
+  - label: "Local toolchain variant → CLAUDE.local.md"
+    description: "Per-checkout build runner override (only relevant on this machine)"
   - label: "None"
     description: "Skip saving, nothing worth keeping"
 ```
 
 Example with 1 discovery:
 ```
-question: "Save this knowledge to project CLAUDE.md?"
+question: "Save this knowledge?"
 options:
-  - label: "Yes"
+  - label: "Yes → project CLAUDE.md"
     description: "Save: [brief description of the discovery]"
   - label: "No"
     description: "Skip saving"
 ```
 
 After user selection:
-- "All" -> save everything
+- "All" -> save everything to its inferred destination
 - "None" -> end without saving
-- Specific item -> save only that item
-- "Other" -> user types custom selection (comma-separated items or partial list)
+- Specific item -> save only that item, to the inferred destination shown in the label
+- "Other" -> user types custom selection of **which discoveries** to save (comma-separated item names). Destinations follow the labels shown — `"Other"` does NOT redirect a destination to an arbitrary path. To override a routing decision, the user should decline the auto-classification, edit the destination file manually, or re-invoke the skill with explicit instructions.
 
 ## Important Guidelines
 - Only capture genuinely new discoveries from this session
-- Don't duplicate existing project or user CLAUDE.md content
+- Don't duplicate existing project CLAUDE.md, `CLAUDE.local.md`, or user CLAUDE.md content
 - Focus on patterns observed, not specific code written
 - Keep descriptions concise and actionable
 - MUST use AskUserQuestion tool for confirmation (not plain text questions)
 - If no knowledge found, exit early without asking
+- **Defer to project- or user-level memory-placement guidance discovered in step 1** — do not override existing conventions with this skill's defaults

--- a/plugins/workflow/skills/learn/SKILL.md
+++ b/plugins/workflow/skills/learn/SKILL.md
@@ -89,7 +89,7 @@ Ask yourself for each discovery:
 Before applying the routing rules below, scan the project's root `CLAUDE.md`, any `.claude/rules/*.md` files, and the user's global `~/.claude/CLAUDE.md` for documented memory-placement guidance — for example, a placement decision tree, an instruction to use a project-specific triage command, or specific destinations beyond `CLAUDE.md` / `CLAUDE.local.md`. If such guidance exists, defer to it: follow the documented workflow or place each discovery according to its rules instead of using this skill's defaults. The remaining steps apply only when no such guidance is found.
 
 ### 2. Check Existing Memory Content
-Read the current content of project `CLAUDE.md` (and `CLAUDE.local.md` if present) to avoid duplication.
+Read the current content of project `CLAUDE.md`, `CLAUDE.local.md` (if present), and the user's global `~/.claude/CLAUDE.md` to avoid duplication — including cross-project entries already captured in user memory.
 
 ### 3. Early Exit if Nothing Found
 If no new strategic knowledge was discovered during this session:
@@ -119,7 +119,7 @@ Build options dynamically based on discoveries:
 - User can always type custom selection via "Other"
 
 Example with 3 discoveries (2 project, 1 personal):
-```
+```yaml
 question: "Which knowledge should I save?"
 options:
   - label: "All (3 items)"
@@ -133,7 +133,7 @@ options:
 ```
 
 Example with 1 discovery:
-```
+```yaml
 question: "Save this knowledge?"
 options:
   - label: "Yes → project CLAUDE.md"


### PR DESCRIPTION
## Summary

Stacked on top of #24 (terminology rename). This PR contains the **routing + deference + label** half of the original #23, with revisions addressing the review feedback there.

> **Note for reviewers:** the diff below shows both #24 and this PR's changes against `master` until #24 merges. For the *isolated* PR B diff (just the routing additions), use the compare view: [`rename-claude-md-terminology…learn-skill-routing-and-deference`](https://github.com/alexkart/cc-thingz/compare/rename-claude-md-terminology...learn-skill-routing-and-deference).

## What this PR does

1. **Adds opt-in routing to `CLAUDE.local.md`** for genuinely personal / per-checkout discoveries. Gated on **both** conditions:
   - `CLAUDE.local.md` already exists in the project (the project has opted into the three-tier convention).
   - The discovery describes per-developer / per-checkout state — not just *mentions* something personal, but the knowledge itself is meaningful only to the current developer on this machine.

2. **Adds a memory-placement deference clause as Workflow step 1.** If the project's `CLAUDE.md`, any `.claude/rules/*.md`, or the user's `~/.claude/CLAUDE.md` documents its own placement workflow (decision tree, triage command, custom destinations), the skill defers to that guidance instead of imposing its own defaults.

3. **Surfaces inferred destinations in `AskUserQuestion` labels** (`Service discovery pattern → CLAUDE.md`, `Local toolchain variant → CLAUDE.local.md`) so users can see the routing per-item.

4. **Bumps the workflow plugin to `1.1.0`** (minor — new routing logic and deference behavior, not a strict bug fix).

## Addressing the review on #23

Two concerns were raised on the bundled #23. Both are addressed in this version:

### Concern 1 — Heuristic over-fits team-wide notes that mention user-home paths

> Example: *"we keep credentials in `~/.aws/credentials`"* — team-wide knowledge, but the path is user-home.

Mitigated by:
- **Tightening the trigger criterion** from "references user-home paths…" to "describes per-developer / per-checkout state — not just *mentions* something personal, but the knowledge itself is meaningful only to the current developer."
- **Adding an explicit counter-example** in the Destinations section: *"we keep credentials in `~/.aws/credentials`" mentions a user-home path but describes a team-wide convention — the path is illustrative, not per-developer state. Such notes belong in `CLAUDE.md`.*
- **Reaffirming the fail-loud default** for ambiguous cases.

Open question for review: is this enough, or would you prefer to remove auto-classification entirely and always show both options in the `AskUserQuestion` prompt? Happy to iterate.

### Concern 2 — `"Other"` widens the `Edit` blast radius

The original draft allowed `"Other"` to redirect destinations to arbitrary paths. Tightened:

> `"Other"` -> user types custom selection of **which discoveries** to save (comma-separated item names). Destinations follow the labels shown — `"Other"` does NOT redirect a destination to an arbitrary path.

Destination overrides require the user to decline the auto-classification, edit the destination file manually, or re-invoke the skill with explicit instructions — no free-text Edit-target redirection.

## Why this is a separate PR

Per your review on #23: bundling the rename (mergeable as-is) with this routing design (debatable) forced an all-or-nothing decision. Split so the rename can merge independently and this design can be discussed on its own merits.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Updates**
  * /workflow:learn now saves strategic project knowledge to the project memory file by default and routes per-developer/checkout-specific discoveries to a local developer memory file when present.
  * Memory-placement now defers to existing project/global placement guidance to avoid duplication.
  * Workflow plugin version bumped to 1.1.0

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/umputun/cc-thingz/pull/25?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->