### PR TITLE
fix(planning): move completed plan to docs/plans/completed/ at exec completion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ This repo ships independent Claude Code plugins. Version headings use values fro
 
 Entries are sorted by plugin version date, newest first.
 
+## planning v3.7.5 - 2026-06-09
+
+### Bug Fixes
+
+- exec: move the finished plan into `docs/plans/completed/` at completion. The plan's final "move to completed/" checkbox was marked `[x]` by a task subagent but the file never moved (the orchestrator explicitly refused, and a mid-run move would break every later phase's `PLAN_FILE_PATH`). Step 13 now performs the move via a VCS-aware `move-plan.sh` (git/hg), committing without pushing, so finished plans leave `docs/plans/` and stop re-appearing as `/planning:exec` candidates.
+- exec: forbid task subagents from moving/renaming the plan file. A subagent could interpret the "move to completed/" checkbox as an automatable `git mv` and abort the run when the orchestrator's `PLAN_FILE_PATH` re-read failed; the task prompt now marks such a checkbox `[x]` and leaves the move to the harness.
+
 ## planning v3.7.4 - 2026-06-02
 
 ### Improvements

--- a/README.md
+++ b/README.md
@@ -237,6 +237,7 @@ Run tests: `python3 plugins/planning/hooks/plan-annotate.py --test`
 5. **Critical-only review** — 2 agents (quality + implementation), critical/major issues only + fixer
 6. **Finalize** — rebase, squash, verify (optional)
 7. **Stats summary** — single agent reads the session log + git state and reports total tokens / wall-clock / per-phase breakdown / branch churn / fixer iterations
+8. **Completion** — moves the finished plan into a `completed/` subdirectory of its plans directory and commits the move (VCS-aware via `move-plan.sh`, no push), so completed plans leave the active plans directory and stop showing up as candidates on the next run
 
 Review agents are read-only reporters. The fixer agent evaluates each finding, fixes confirmed issues, rejects false positives, and reports back.
 

--- a/plugins/planning/.claude-plugin/plugin.json
+++ b/plugins/planning/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "planning",
   "description": "Structured implementation planning, interactive annotation review, and autonomous plan execution",
-  "version": "3.7.4",
+  "version": "3.7.5",
   "author": {
     "name": "Umputun"
   },

--- a/plugins/planning/skills/exec/SKILL.md
+++ b/plugins/planning/skills/exec/SKILL.md
@@ -270,8 +270,8 @@ This step is best-effort — if the stats agent fails or the session log path ca
 
 When stats summary is done (or skipped on failure):
 - Log completion to progress file: `bash ${CLAUDE_PLUGIN_ROOT}/skills/exec/scripts/append-progress.sh <progress-file> "completed"`
-- Report final line: "All N tasks completed, reviews passed, branch finalized"
-- Do NOT move the plan file or push — just report completion
+- Move the finished plan into its `completed/` subdirectory and commit it (best-effort): `bash ${CLAUDE_PLUGIN_ROOT}/skills/exec/scripts/move-plan.sh <plan-file-path>`. The script is a no-op when the plan is already under `completed/` or missing, derives the target as a `completed/` sibling of the plan's directory (so it respects a custom `plans_dir` and worktrees), and commits the move VCS-aware (git/hg). Do NOT push. If the script exits non-zero, report the failure but do not block completion.
+- Report final line: "All N tasks completed, reviews passed, branch finalized, plan moved to completed/"
 
 ## Key rules
 
@@ -280,7 +280,7 @@ When stats summary is done (or skipped on failure):
 - Plan file is the single source of truth for progress — always re-read it
 - No signals — just checkboxes in the plan for task progress
 - Maintain progress file (`/tmp/progress-<plan-name>.txt`) — see `prompts/progress-file.md` for format and when to write
-- Do not modify the plan file yourself — only subagents modify it
+- Do not modify the plan file yourself during the task, review, and finalize phases — only subagents modify it. The sole exception is the terminal move in step 13 (after all phases finish), which the orchestrator performs via `move-plan.sh`
 - Do not implement or fix code yourself — only subagents implement and fix
 - If a subagent fails or leaves broken code, re-run the loop — do NOT investigate or fix it yourself
 - NEVER dismiss findings as "pre-existing", "not from changes", or "architectural" — ALL findings are actionable

--- a/plugins/planning/skills/exec/references/prompts/task.md
+++ b/plugins/planning/skills/exec/references/prompts/task.md
@@ -7,6 +7,8 @@ Read the plan file at PLAN_FILE_PATH. Find the FIRST Task section (### Task N: o
 
 If a Task section has [ ] checkboxes you cannot complete (manual testing, deployment verification, external checks): mark them [x] with a note like "[x] manual test (skipped - not automatable)" and proceed.
 
+NEVER move, rename, or delete the plan file (PLAN_FILE_PATH) itself, even when a checkbox says to move it to a "completed/" directory. The harness moves the plan after all phases finish. If you encounter such a checkbox, mark it [x] and proceed without moving anything — moving it mid-run breaks every later review, finalize, and stats phase that reads PLAN_FILE_PATH.
+
 CRITICAL CONSTRAINT: Complete ONE Task section per iteration.
 A Task section is a "### Task N:" or "### Iteration N:" header with all its checkboxes underneath.
 Complete ALL checkboxes in that section, then STOP.

--- a/plugins/planning/skills/exec/scripts/move-plan.sh
+++ b/plugins/planning/skills/exec/scripts/move-plan.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+# move a completed plan file into its sibling completed/ directory and commit it
+# usage: move-plan.sh <plan-file-path>
+# no-op if the plan is already under completed/ or the file is missing
+# VCS-aware commit via stage-and-commit.sh; does NOT push
+
+set -e
+
+if [ $# -lt 1 ]; then
+    echo "error: usage: move-plan.sh <plan-file-path>" >&2
+    exit 1
+fi
+
+plan="$1"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+# already under completed/ — nothing to do
+case "$plan" in
+*/completed/*)
+    echo "plan already under completed/: $plan"
+    exit 0
+    ;;
+esac
+
+# file missing (already moved, or never existed) — nothing to do
+if [ ! -f "$plan" ]; then
+    echo "plan file not found, skipping move: $plan" >&2
+    exit 0
+fi
+
+base="$(basename "$plan")"
+dest_dir="$(dirname "$plan")/completed"
+dest="$dest_dir/$base"
+
+mkdir -p "$dest_dir"
+mv "$plan" "$dest"
+
+# stage-and-commit.sh stages both the (now-removed) old path and the new path;
+# git and hg each record this as the rename plus commit
+bash "$SCRIPT_DIR/stage-and-commit.sh" "docs: move completed plan $base to completed/" "$plan" "$dest"
+
+echo "moved plan to $dest"

--- a/tests/test-exec-vcs-dispatch.sh
+++ b/tests/test-exec-vcs-dispatch.sh
@@ -13,6 +13,7 @@ DETECT_BRANCH="$EXEC_SCRIPTS_DIR/detect-branch.sh"
 CREATE_BRANCH="$EXEC_SCRIPTS_DIR/create-branch.sh"
 STAGE_AND_COMMIT="$EXEC_SCRIPTS_DIR/stage-and-commit.sh"
 RUN_CODEX="$EXEC_SCRIPTS_DIR/run-codex.sh"
+MOVE_PLAN="$EXEC_SCRIPTS_DIR/move-plan.sh"
 
 passed=0
 failed=0
@@ -611,6 +612,98 @@ echo "test 20: run-codex.sh exits non-zero in empty dir"
 rc=0
 (cd "$EMPTY_DIR" && PATH="$STUB_DIR:$PATH" bash "$RUN_CODEX" "prompt" >/dev/null 2>&1) || rc=$?
 assert_exit_nonzero "run-codex.sh: empty dir exits non-zero" "$rc"
+
+echo ""
+echo "testing VCS dispatch: move-plan.sh"
+echo "=================================="
+
+PLAN_NAME="20260329-feature-name.md"
+EXPECTED_MOVE_SUBJECT="docs: move completed plan $PLAN_NAME to completed/"
+
+# test 21: git repo, finished plan -> moved into completed/ and committed as a rename
+echo ""
+echo "test 21: git repo, plan moved into completed/ + committed"
+GIT_MV="$(mk_tmp)"
+make_git_repo "$GIT_MV" main
+(
+    cd "$GIT_MV"
+    mkdir -p docs/plans
+    echo "# plan" >"docs/plans/$PLAN_NAME"
+    git add "docs/plans/$PLAN_NAME"
+    git commit -q -m "add plan"
+)
+commits_before="$(git -C "$GIT_MV" rev-list --count HEAD)"
+rc=0
+(cd "$GIT_MV" && bash "$MOVE_PLAN" "docs/plans/$PLAN_NAME" >/dev/null 2>&1) || rc=$?
+assert_output "git/move: exit code 0" "0" "$rc"
+[ ! -f "$GIT_MV/docs/plans/$PLAN_NAME" ] && orig="gone" || orig="present"
+assert_output "git/move: original path removed" "gone" "$orig"
+[ -f "$GIT_MV/docs/plans/completed/$PLAN_NAME" ] && dest="present" || dest="missing"
+assert_output "git/move: file now under completed/" "present" "$dest"
+subject="$(git -C "$GIT_MV" log -1 --pretty=%s)"
+assert_output "git/move: commit subject matches" "$EXPECTED_MOVE_SUBJECT" "$subject"
+commits_after="$(git -C "$GIT_MV" rev-list --count HEAD)"
+assert_output "git/move: exactly one new commit" "$((commits_before + 1))" "$commits_after"
+files="$(git -C "$GIT_MV" show --name-status --pretty=format: HEAD | sed '/^$/d')"
+assert_contains "git/move: commit records completed/ path" "$files" "docs/plans/completed/$PLAN_NAME"
+
+# test 22: git repo, re-run on the now-missing original path -> no-op exit 0, no new commit
+echo ""
+echo "test 22: git repo, re-run on already-moved plan -> no-op"
+rc=0
+out="$(cd "$GIT_MV" && bash "$MOVE_PLAN" "docs/plans/$PLAN_NAME" 2>&1)" || rc=$?
+assert_output "git/move-again: exit code 0 (no-op)" "0" "$rc"
+assert_contains "git/move-again: reports missing file" "$out" "plan file not found"
+commits_after2="$(git -C "$GIT_MV" rev-list --count HEAD)"
+assert_output "git/move-again: no additional commit" "$((commits_before + 1))" "$commits_after2"
+
+# test 23: path already under completed/ -> no-op, file untouched, no commit
+echo ""
+echo "test 23: git repo, path already under completed/ -> no-op"
+GIT_MV_DONE="$(mk_tmp)"
+make_git_repo "$GIT_MV_DONE" main
+(
+    cd "$GIT_MV_DONE"
+    mkdir -p docs/plans/completed
+    echo "# plan" >"docs/plans/completed/$PLAN_NAME"
+    git add "docs/plans/completed/$PLAN_NAME"
+    git commit -q -m "add completed plan"
+)
+commits_before="$(git -C "$GIT_MV_DONE" rev-list --count HEAD)"
+rc=0
+out="$(cd "$GIT_MV_DONE" && bash "$MOVE_PLAN" "docs/plans/completed/$PLAN_NAME" 2>&1)" || rc=$?
+assert_output "git/already-completed: exit code 0" "0" "$rc"
+assert_contains "git/already-completed: reports already under completed/" "$out" "already under completed/"
+[ -f "$GIT_MV_DONE/docs/plans/completed/$PLAN_NAME" ] && still="present" || still="missing"
+assert_output "git/already-completed: file untouched" "present" "$still"
+commits_after="$(git -C "$GIT_MV_DONE" rev-list --count HEAD)"
+assert_output "git/already-completed: no new commit" "$commits_before" "$commits_after"
+
+if [ "$HG_AVAILABLE" -eq 1 ]; then
+    # test 24: hg repo, finished plan -> moved into completed/ and committed
+    echo ""
+    echo "test 24: hg repo, plan moved into completed/ + committed"
+    HG_MV="$(mk_tmp)"
+    make_hg_repo "$HG_MV"
+    (
+        cd "$HG_MV"
+        mkdir -p docs/plans
+        echo "# plan" >"docs/plans/$PLAN_NAME"
+        hg add "docs/plans/$PLAN_NAME" >/dev/null
+        hg commit -m "add plan" >/dev/null
+    )
+    rc=0
+    (cd "$HG_MV" && bash "$MOVE_PLAN" "docs/plans/$PLAN_NAME" >/dev/null 2>&1) || rc=$?
+    assert_output "hg/move: exit code 0" "0" "$rc"
+    [ ! -f "$HG_MV/docs/plans/$PLAN_NAME" ] && orig="gone" || orig="present"
+    assert_output "hg/move: original path removed" "gone" "$orig"
+    [ -f "$HG_MV/docs/plans/completed/$PLAN_NAME" ] && dest="present" || dest="missing"
+    assert_output "hg/move: file now under completed/" "present" "$dest"
+    subject="$(cd "$HG_MV" && hg log -l 1 -T '{desc}')"
+    assert_output "hg/move: commit subject matches" "$EXPECTED_MOVE_SUBJECT" "$subject"
+    files="$(cd "$HG_MV" && hg log -l 1 -T '{files}')"
+    assert_contains "hg/move: commit records completed/ path" "$files" "docs/plans/completed/$PLAN_NAME"
+fi
 
 # summary
 echo ""


### PR DESCRIPTION
every `/planning:exec` run finished with the plan's "move this plan to `docs/plans/completed/`" checkbox marked `[x]`, but the file never actually moved. Three parts of the toolchain disagreed about who performs the move and nobody did:

- `commands/make.md` injects the move as a task checkbox into every plan
- the task subagent can't safely move the file mid-run (it invalidates `PLAN_FILE_PATH` for every later phase), so it marks the checkbox `[x]` and moves nothing
- `skills/exec/SKILL.md` step 13 explicitly forbade the orchestrator from moving it

result: a false `[x]`, the file stays in `docs/plans/`, and because step 1 excludes `completed/` from listing, a finished plan re-appears as a candidate on the next no-arg run.

**fix** - step 13 now owns the move via a new `move-plan.sh`. It moves the plan into a `completed/` sibling of its directory and commits it VCS-aware (git/hg), without pushing. It's a no-op when the plan is already under `completed/` or missing, and derives the target from the plan's actual path so it respects a custom `plans_dir` and worktrees. The move runs only after stats (step 12), when no phase reads the plan anymore, so it can't break `PLAN_FILE_PATH`.

also fixes a latent crash: `task.md` only excused items a subagent "cannot complete", but a file move is completable, so a subagent could run `git mv` on the final task and abort the whole run when the orchestrator's `PLAN_FILE_PATH` re-read failed. The task prompt now forbids subagents from moving or renaming the plan and leaves the move to the harness.

`make.md`'s checkbox is left as-is on purpose - it's correct for interactive execution, and always-move in step 13 reconciles both paths.

tests: added `move-plan.sh` coverage (git move, idempotent no-op, already-under-completed, hg move) to `tests/test-exec-vcs-dispatch.sh`. Full suite 93 passed, 0 failed.

bumps planning to 3.7.5.
