### PR TITLE
fix(planning): report plan move honestly and refuse to clobber destination

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ This repo ships independent Claude Code plugins. Version headings use values fro
 
 Entries are sorted by plugin version date, newest first.
 
+## planning v3.7.6 - 2026-06-09
+
+### Bug Fixes
+
+- exec: report the plan move honestly. Step 13 hardcoded "plan moved to completed/" in the final line even though the move is best-effort, so a no-op (plan already under `completed/` or missing) or a failed move would print a false claim. The suffix is now appended only when `move-plan.sh` actually moved the file.
+- exec: `move-plan.sh` refuses to overwrite an existing destination instead of clobbering it. A same-named plan already under `completed/` now causes a non-zero exit (reported, non-blocking) rather than a silent `mv` over the existing file.
+
 ## planning v3.7.5 - 2026-06-09
 
 ### Bug Fixes

--- a/plugins/planning/.claude-plugin/plugin.json
+++ b/plugins/planning/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "planning",
   "description": "Structured implementation planning, interactive annotation review, and autonomous plan execution",
-  "version": "3.7.5",
+  "version": "3.7.6",
   "author": {
     "name": "Umputun"
   },

--- a/plugins/planning/skills/exec/SKILL.md
+++ b/plugins/planning/skills/exec/SKILL.md
@@ -271,7 +271,7 @@ This step is best-effort — if the stats agent fails or the session log path ca
 When stats summary is done (or skipped on failure):
 - Log completion to progress file: `bash ${CLAUDE_PLUGIN_ROOT}/skills/exec/scripts/append-progress.sh <progress-file> "completed"`
 - Move the finished plan into its `completed/` subdirectory and commit it (best-effort): `bash ${CLAUDE_PLUGIN_ROOT}/skills/exec/scripts/move-plan.sh <plan-file-path>`. The script is a no-op when the plan is already under `completed/` or missing, derives the target as a `completed/` sibling of the plan's directory (so it respects a custom `plans_dir` and worktrees), and commits the move VCS-aware (git/hg). Do NOT push. If the script exits non-zero, report the failure but do not block completion.
-- Report final line: "All N tasks completed, reviews passed, branch finalized, plan moved to completed/"
+- Report the final line "All N tasks completed, reviews passed, branch finalized". Append ", plan moved to completed/" ONLY when move-plan.sh actually moved the file (it printed `moved plan to ...`); omit the suffix when the move was a no-op (already under `completed/` or missing) or exited non-zero
 
 ## Key rules
 

--- a/plugins/planning/skills/exec/scripts/move-plan.sh
+++ b/plugins/planning/skills/exec/scripts/move-plan.sh
@@ -32,6 +32,12 @@ base="$(basename "$plan")"
 dest_dir="$(dirname "$plan")/completed"
 dest="$dest_dir/$base"
 
+# refuse to clobber an existing completed plan with the same name
+if [ -e "$dest" ]; then
+    echo "error: destination already exists, refusing to overwrite: $dest" >&2
+    exit 1
+fi
+
 mkdir -p "$dest_dir"
 mv "$plan" "$dest"
 

--- a/tests/test-exec-vcs-dispatch.sh
+++ b/tests/test-exec-vcs-dispatch.sh
@@ -705,6 +705,30 @@ if [ "$HG_AVAILABLE" -eq 1 ]; then
     assert_contains "hg/move: commit records completed/ path" "$files" "docs/plans/completed/$PLAN_NAME"
 fi
 
+# test 25: destination already exists -> refuse to overwrite, exit non-zero, no commit
+echo ""
+echo "test 25: git repo, destination already exists -> refuse, no clobber"
+GIT_MV_CLOBBER="$(mk_tmp)"
+make_git_repo "$GIT_MV_CLOBBER" main
+(
+    cd "$GIT_MV_CLOBBER"
+    mkdir -p docs/plans/completed
+    echo "# new plan" >"docs/plans/$PLAN_NAME"
+    echo "# OLD COMPLETED" >"docs/plans/completed/$PLAN_NAME"
+    git add docs/plans
+    git commit -q -m "plan plus pre-existing completed"
+)
+commits_before="$(git -C "$GIT_MV_CLOBBER" rev-list --count HEAD)"
+rc=0
+(cd "$GIT_MV_CLOBBER" && bash "$MOVE_PLAN" "docs/plans/$PLAN_NAME" >/dev/null 2>&1) || rc=$?
+assert_exit_nonzero "git/clobber: refuses with non-zero exit" "$rc"
+[ -f "$GIT_MV_CLOBBER/docs/plans/$PLAN_NAME" ] && src="present" || src="gone"
+assert_output "git/clobber: source plan left in place" "present" "$src"
+dest_content="$(cat "$GIT_MV_CLOBBER/docs/plans/completed/$PLAN_NAME")"
+assert_output "git/clobber: existing destination not overwritten" "# OLD COMPLETED" "$dest_content"
+commits_after="$(git -C "$GIT_MV_CLOBBER" rev-list --count HEAD)"
+assert_output "git/clobber: no new commit" "$commits_before" "$commits_after"
+
 # summary
 echo ""
 echo "======================================"


### PR DESCRIPTION
follow-up to #28 addressing Copilot's review.

**point 2 (valid)** - step 13's final line hardcoded "plan moved to completed/" even though `move-plan.sh` is best-effort. On a no-op (plan already under `completed/`, or a hand-authored plan that's missing) or a failed move, that line lied. The suffix is now appended only when the script actually moved the file.

**point 1 (overwrite sliver)** - `move-plan.sh` now refuses to overwrite an existing destination. A same-named plan already under `completed/` causes a non-zero exit (reported, non-blocking) instead of a silent `mv` over it. Date-prefixed plan names make this near-impossible, but the guard is cheap.

the rest of point 1 doesn't hold: `git add -- <old> <new>` stages the deletion of the now-missing old path on git >= 2.0 and records a rename (`R100`), so the commit goes through fine - the merged test 21 and a fresh isolated check on git 2.54 both confirm exit 0 + rename. `mv` doesn't defeat git's content-based rename detection.

tests: added a git clobber case. Full suite 97 passed, 0 failed.

bumps planning to 3.7.6.
