### PR TITLE
fix(ask-codex): drop invalid project_doc flags, add memory-load preamble, default to xhigh

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,7 +284,7 @@ Environment variables read by `run-codex.sh`:
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `CODEX_MODEL` | `gpt-5.5` | Model name passed to `codex exec` via `-c model=...` |
-| `CODEX_NO_OVERRIDES` | *(unset)* | When set to the literal value `1`, suppresses all `-c` overrides (`model`, `model_reasoning_effort`, `stream_idle_timeout_ms`, `project_doc`). Useful for codex proxies / wrappers that reject `-c model/provider` overrides. Any other value (including `0`, `false`, empty) leaves the overrides on. |
+| `CODEX_NO_OVERRIDES` | *(unset)* | When set to the literal value `1`, suppresses all `-c` overrides (`model`, `model_reasoning_effort`, `stream_idle_timeout_ms`). Useful for codex proxies / wrappers that reject `-c model/provider` overrides. Any other value (including `0`, `false`, empty) leaves the overrides on. |
 
 ### release-tools
 

--- a/plugins/planning/skills/exec/scripts/run-codex.sh
+++ b/plugins/planning/skills/exec/scripts/run-codex.sh
@@ -34,8 +34,6 @@ if [ "${CODEX_NO_OVERRIDES:-}" != 1 ]; then
         "-c" "model=${CODEX_MODEL:-gpt-5.5}"
         "-c" "model_reasoning_effort=xhigh"
         "-c" "stream_idle_timeout_ms=3600000"
-        "-c" "project_doc=$HOME/.claude/CLAUDE.md"
-        "-c" "project_doc=./CLAUDE.md"
     )
 fi
 

--- a/plugins/thinking-tools/skills/ask-codex/SKILL.md
+++ b/plugins/thinking-tools/skills/ask-codex/SKILL.md
@@ -6,7 +6,7 @@ allowed-tools: Bash, Read, Grep, Glob
 
 # Ask Codex
 
-Consult OpenAI Codex (GPT-5) as a second opinion for investigation, debugging, or review tasks.
+Consult OpenAI Codex (GPT-5.5) as a second opinion for investigation, debugging, or review tasks.
 
 ## Activation Triggers
 
@@ -35,11 +35,21 @@ Gather context from the current conversation:
 3. **What we tried** — approaches attempted and why they failed (if applicable)
 4. **Specific question** — what exactly codex should analyze or answer
 
-If CLAUDE.md exists in the project, it will be passed as project context.
+Codex does NOT auto-load Claude Code's memory files — it only reads `AGENTS.md`. To give Codex the same project context Claude follows, prepend the memory-load preamble described in Step 3.
 
 ### Step 3: Construct Prompt
 
 Build a focused prompt. Do NOT dump entire files — codex has full project access and can read them itself. Provide file paths and line references so codex knows where to look.
+
+**Prepend a memory-load preamble.** Codex auto-loads only `AGENTS.md`; it does NOT read Claude Code's memory files (`CLAUDE.md`, `CLAUDE.local.md`, `.claude/rules/`, `~/.claude/CLAUDE.md`), so the project conventions Claude follows are invisible to Codex unless you tell it to read them. Prepend this line to the prompt:
+
+```
+First read these project guidance files if present: <ABS_HOME>/.claude/CLAUDE.md, CLAUDE.md, CLAUDE.local.md, .claude/rules/
+```
+
+- Resolve `<ABS_HOME>` to the **absolute** home path (run `echo $HOME`, e.g. `/home/<user>`) and write the literal path. Do NOT pass the string `$HOME`: the prompt is delivered via `$(cat ...)` (command-substitution output is not re-scanned for variable expansion), and Codex may open the file with a non-shell tool that won't expand it.
+- No `@` prefix — `@file` is inert in `codex exec` (literal text, not an import).
+- The project-relative paths resolve against Codex's working directory; Codex skips any that don't exist.
 
 **Template for investigation/debug:**
 
@@ -157,10 +167,8 @@ Run codex in background (it takes 2-5 minutes for complex analysis):
 ```bash
 codex exec -m gpt-5.5 \
   --sandbox read-only \
-  -c model_reasoning_effort="high" \
+  -c model_reasoning_effort="xhigh" \
   -c stream_idle_timeout_ms=600000 \
-  -c project_doc="$HOME/.claude/CLAUDE.md" \
-  -c project_doc="./CLAUDE.md" \
   "prompt here"
 ```
 
@@ -173,8 +181,7 @@ codex exec -m gpt-5.5 \
 **Flags:**
 - `--sandbox read-only` — codex can read all project files but cannot modify anything
 - `-m gpt-5.5` — latest model (adjust as newer versions become available)
-- `model_reasoning_effort="high"` — maximum reasoning depth
-- `project_doc` — passes CLAUDE.md as project context (both global and local if present)
+- `model_reasoning_effort="xhigh"` — deepest reasoning tier (Codex now exposes `xhigh` above `high`; `high` is no longer the maximum)
 
 ### Step 5: Present Results
 

--- a/plugins/thinking-tools/skills/ask-codex/SKILL.md
+++ b/plugins/thinking-tools/skills/ask-codex/SKILL.md
@@ -181,7 +181,7 @@ codex exec -m gpt-5.5 \
 **Flags:**
 - `--sandbox read-only` — codex can read all project files but cannot modify anything
 - `-m gpt-5.5` — latest model (adjust as newer versions become available)
-- `model_reasoning_effort="xhigh"` — deepest reasoning tier (Codex now exposes `xhigh` above `high`; `high` is no longer the maximum)
+- `model_reasoning_effort="xhigh"` — deepest reasoning tier
 
 ### Step 5: Present Results
 

--- a/plugins/thinking-tools/skills/ask-codex/SKILL.md
+++ b/plugins/thinking-tools/skills/ask-codex/SKILL.md
@@ -47,7 +47,7 @@ Build a focused prompt. Do NOT dump entire files — codex has full project acce
 First read these project guidance files if present: <ABS_HOME>/.claude/CLAUDE.md, CLAUDE.md, CLAUDE.local.md, .claude/rules/
 ```
 
-- Resolve `<ABS_HOME>` to the **absolute** home path (run `echo $HOME`, e.g. `/home/<user>`) and write the literal path. Do NOT pass the string `$HOME`: the prompt is delivered via `$(cat ...)` (command-substitution output is not re-scanned for variable expansion), and Codex may open the file with a non-shell tool that won't expand it.
+- Resolve `<ABS_HOME>` to the **absolute** home path (run `echo $HOME`, e.g. `/home/<user>`) and write the literal path — do NOT leave the string `$HOME` in the prompt. Whether `$HOME` expands depends on how the prompt is passed to Codex, and Codex may open the file with a non-shell tool that never expands it, so only a literal absolute path is reliable.
 - No `@` prefix — `@file` is inert in `codex exec` (literal text, not an import).
 - The project-relative paths resolve against Codex's working directory; Codex skips any that don't exist.
 

--- a/plugins/thinking-tools/skills/ask-codex/SKILL.md
+++ b/plugins/thinking-tools/skills/ask-codex/SKILL.md
@@ -169,10 +169,11 @@ codex exec -m gpt-5.5 \
   --sandbox read-only \
   -c model_reasoning_effort="xhigh" \
   -c stream_idle_timeout_ms=600000 \
-  "prompt here"
+  "prompt here" < /dev/null
 ```
 
 **Execution rules:**
+- Always end the invocation with `< /dev/null` (as shown). `codex exec` reads stdin to append a `<stdin>` block even when the prompt is a positional arg, so an inherited open pipe (common under a background launch) never closes and codex blocks forever on "Reading additional input from stdin…"; `/dev/null` gives immediate EOF.
 - Always use `run_in_background: true` in Bash tool
 - Monitor with BashOutput every 15-20 seconds
 - Be patient during reasoning phase (1-3 minutes of silence is normal)
@@ -256,3 +257,4 @@ Parse the JSON output and present findings sorted by severity, filtered by confi
 - **Authentication**: `codex login` if getting auth errors
 - **Timeout**: increase `stream_idle_timeout_ms` for complex analyses
 - **Off-target response**: refine prompt with more specific file:line references
+- **Hangs on "Reading additional input from stdin…"**: the invocation is missing the `< /dev/null` stdin redirect — add it (see Step 4).

--- a/tests/test-exec-vcs-dispatch.sh
+++ b/tests/test-exec-vcs-dispatch.sh
@@ -511,7 +511,7 @@ assert_contains "git: --sandbox is present" "$stub_out" "--sandbox"
 assert_contains "git: -c model= flag present" "$stub_out" "model=gpt-5.5"
 assert_contains "git: -c model_reasoning_effort= flag present" "$stub_out" "model_reasoning_effort=xhigh"
 assert_contains "git: -c stream_idle_timeout_ms= flag present" "$stub_out" "stream_idle_timeout_ms=3600000"
-assert_contains "git: project_doc=./CLAUDE.md flag present" "$stub_out" "project_doc=./CLAUDE.md"
+assert_not_contains "git: no project_doc flag (dead Codex config key, removed)" "$stub_out" "project_doc"
 assert_contains "git: prompt is passed through" "$stub_out" "hello prompt"
 
 # test 15b: git repo with CODEX_MODEL override -> model is overridden
@@ -528,7 +528,6 @@ stub_out="$(cd "$GIT_RC" && CODEX_NO_OVERRIDES=1 PATH="$STUB_DIR:$PATH" bash "$R
 assert_not_contains "git: no -c model= when CODEX_NO_OVERRIDES=1" "$stub_out" "model=gpt-5.5"
 assert_not_contains "git: no -c model_reasoning_effort= when CODEX_NO_OVERRIDES=1" "$stub_out" "model_reasoning_effort"
 assert_not_contains "git: no -c stream_idle_timeout_ms= when CODEX_NO_OVERRIDES=1" "$stub_out" "stream_idle_timeout_ms"
-assert_not_contains "git: no project_doc when CODEX_NO_OVERRIDES=1" "$stub_out" "project_doc"
 # non -c args (exec / --sandbox / prompt) must still be there
 assert_contains "git: exec still present with CODEX_NO_OVERRIDES=1" "$stub_out" "exec"
 assert_contains "git: --sandbox still present with CODEX_NO_OVERRIDES=1" "$stub_out" "--sandbox"
@@ -565,7 +564,7 @@ if [ "$HG_AVAILABLE" -eq 1 ]; then
     assert_contains "hg: --sandbox is present" "$stub_out" "--sandbox"
     assert_contains "hg: -c model= flag present" "$stub_out" "model=gpt-5.5"
     assert_contains "hg: -c model_reasoning_effort= flag present" "$stub_out" "model_reasoning_effort=xhigh"
-    assert_contains "hg: project_doc=./CLAUDE.md flag present" "$stub_out" "project_doc=./CLAUDE.md"
+    assert_not_contains "hg: no project_doc flag (dead Codex config key, removed)" "$stub_out" "project_doc"
     assert_contains "hg: prompt is passed through" "$stub_out" "hello prompt"
 
     # verify ordering: exec, then --skip-git-repo-check, then --sandbox


### PR DESCRIPTION
## What

The skill's `codex exec` invocation passes `-c project_doc="$HOME/.claude/CLAUDE.md" -c project_doc="./CLAUDE.md"` to give Codex the project's `CLAUDE.md` as context — but `project_doc` is **not a valid Codex config key**, so those flags silently load nothing. This PR removes them and replaces the intent with a prompt-level memory-load preamble, plus two small fixes.

## Why `project_doc` doesn't work (verified on codex-cli 0.141.0)

- `codex exec --strict-config -c project_doc=...` → `Error loading config.toml: unknown configuration field 'project_doc' in -c/--config override`.
- Without `--strict-config`, unknown `-c` overrides are silently ignored.
- `codex debug prompt-input` renders a **byte-identical** model-visible prompt with and without the `-c project_doc=...` flags — confirming they inject nothing.

Codex auto-loads only `AGENTS.md` (repo-root + nested + `~/.codex/AGENTS.md`); it does not read Claude Code's memory files, and there is no CLI flag (and no `@file` mechanism) to force-load an arbitrary file.

## Changes

1. **Remove the dead `-c project_doc=...` flags** from the `codex exec` command and the Flags list.
2. **Add a Step 3 "memory-load preamble"** — prepend to the prompt:
   `First read these project guidance files if present: <ABS_HOME>/.claude/CLAUDE.md, CLAUDE.md, CLAUDE.local.md, .claude/rules/`
   This works in any project (no `AGENTS.md` required). `<ABS_HOME>` must be resolved to an absolute path — a literal `$HOME` isn't reliably expanded (whether it expands depends on how the prompt is passed to Codex, and Codex may open the file with a non-shell tool that never expands it). Verified: with this preamble Codex reads every listed file (including the out-of-repo `~/.claude/CLAUDE.md`) and quotes them back correctly.
3. **`model_reasoning_effort`: `high` → `xhigh`** + fix the stale "maximum reasoning depth" wording, since Codex now exposes `xhigh` above `high`.
4. **Consistency:** the intro now says "GPT-5.5" to match `-m gpt-5.5`.

## Folded in during review

- **Dropped the same dead `project_doc` flags from the `planning:exec` codex pass** — `run-codex.sh`, the `CODEX_NO_OVERRIDES` list in `README.md`, and the dispatch tests (the two presence-asserts become `assert_not_contains` regression guards).
- **Added the `< /dev/null` stdin redirect to the `codex exec` template** (mirroring what `run-codex.sh` already does), fixing the hang where `codex exec` blocks on "Reading additional input from stdin…" because it reads stdin even with a positional prompt arg.

Closes #26
