### PR TITLE
fix(planning): skip plan review on remote clients via PLANNING_DISABLE_REVDIFF

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ This repo ships independent Claude Code plugins. Version headings use values fro
 
 Entries are sorted by plugin version date, newest first.
 
+## planning v3.8.1 - 2026-06-29
+
+### Bug Fixes
+
+- plan review: add `PLANNING_DISABLE_REVDIFF=1` to skip interactive plan review entirely on both routes (the `ExitPlanMode` hook and `/planning:make`). Under `claude /remote-control` the overlay opened on the host terminal the remote client cannot see, blocking the session indefinitely; the flag bypasses both revdiff and the `$EDITOR` fallback and falls through to the normal `ExitPlanMode` confirmation #32
+
 ## planning v3.8.0 - 2026-06-28
 
 ### New Features

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ cp plugins/planning/commands/make.md ~/.claude/commands/
 cp -r plugins/planning/skills/exec ~/.claude/skills/
 cp -r plugins/planning/scripts/ ~/.claude/commands/scripts
 cp -r plugins/planning/references/ ~/.claude/commands/references
-cp plugins/planning/hooks/plan-annotate.py ~/.claude/scripts/
+cp plugins/planning/scripts/plan-annotate.py ~/.claude/scripts/
 chmod +x ~/.claude/scripts/plan-annotate.py
 chmod +x ~/.claude/skills/exec/scripts/*.sh
 ```
@@ -217,6 +217,8 @@ listen_on unix:/tmp/kitty-$KITTY_PID
 
 *Note*: when `revdiff` is installed, the `ExitPlanMode` hook and `/planning:make` interactive review both route through `launch-plan-review.sh` instead, which supports a wider set of overlays: agterm, tmux, zellij, herdr, kitty, wezterm/kaku, cmux, ghostty, iTerm2, and emacs vterm. The 3-terminal list above applies only to the `$EDITOR` fallback when revdiff is not installed.
 
+*Disabling review*: set `PLANNING_DISABLE_REVDIFF=1` to skip interactive plan review entirely on both routes (revdiff and the `$EDITOR` fallback). No overlay opens and the plan proceeds to the normal `ExitPlanMode` confirmation. This exists for remote clients (`claude /remote-control`): the overlay always opens on the host terminal, which a mobile or web client cannot see or interact with, so review would otherwise block the session. The variable is read when review fires, so export it in your shell before starting a session you may later drive remotely.
+
 The overlay popup size is configurable via env vars:
 
 | Env var | Description | Default |
@@ -224,7 +226,7 @@ The overlay popup size is configurable via env vars:
 | `REVDIFF_POPUP_WIDTH` | Tmux/Zellij popup width (e.g., `100%`, `80%`) | `90%` |
 | `REVDIFF_POPUP_HEIGHT` | Tmux/Zellij popup height / wezterm split percent | `90%` |
 
-Run tests: `python3 plugins/planning/hooks/plan-annotate.py --test`
+Run tests: `python3 plugins/planning/scripts/plan-annotate.py --test`
 
 **plan-review agent** — automated plan quality reviewer. Analyzes plans for problem definition, solution correctness, scope creep, over-engineering, testing requirements, task granularity, and convention adherence. Used by the plan command's "Auto review" option. Outputs a structured report with severity-rated findings and an APPROVE/NEEDS REVISION verdict.
 

--- a/plugins/planning/.claude-plugin/plugin.json
+++ b/plugins/planning/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "planning",
   "description": "Structured implementation planning, interactive annotation review, and autonomous plan execution",
-  "version": "3.8.0",
+  "version": "3.8.1",
   "author": {
     "name": "Umputun"
   },

--- a/plugins/planning/scripts/launch-plan-review.sh
+++ b/plugins/planning/scripts/launch-plan-review.sh
@@ -11,6 +11,13 @@ if [ $# -lt 1 ]; then
     exit 1
 fi
 
+# skip review entirely when disabled (e.g. claude /remote-control, where this overlay
+# would open on the host terminal the remote client can't see and block the session).
+# empty stdout signals "no annotations", so the hook and /planning:make loop proceed.
+if [ -n "${PLANNING_DISABLE_REVDIFF:-}" ]; then
+    exit 0
+fi
+
 PLAN_FILE="$1"
 
 if [ ! -f "$PLAN_FILE" ]; then

--- a/plugins/planning/scripts/plan-annotate.py
+++ b/plugins/planning/scripts/plan-annotate.py
@@ -80,6 +80,13 @@ def read_plan_from_stdin() -> str:
         return ""
 
 
+def review_disabled() -> bool:
+    """report whether interactive plan review is disabled via PLANNING_DISABLE_REVDIFF.
+    set this on a remote client (claude /remote-control), where the editor overlay would
+    open on the host terminal the remote client can't see and block the session."""
+    return bool(os.environ.get("PLANNING_DISABLE_REVDIFF"))
+
+
 def make_response(decision: str, reason: str = "") -> str:
     """build PreToolUse hook JSON response."""
     resp: dict = {
@@ -174,6 +181,8 @@ def open_editor(filepath: Path, target_window: bool = True) -> int:
 
 def run_file_mode(plan_file: Path) -> None:
     """file mode: open plan copy in editor, output diff to stdout."""
+    if review_disabled():
+        return
     if not plan_file.exists():
         print(f"error: file not found: {plan_file}", file=sys.stderr)
         sys.exit(1)
@@ -201,6 +210,9 @@ def run_file_mode(plan_file: Path) -> None:
 
 def run_hook_mode() -> None:
     """hook mode: read plan from stdin JSON, output hook response."""
+    if review_disabled():
+        print(make_response("ask", "plan review disabled via PLANNING_DISABLE_REVDIFF"))
+        return
     plan_content = read_plan_from_stdin()
     if not plan_content:
         print(make_response("ask", "no plan content in hook event"))
@@ -365,9 +377,46 @@ def run_tests() -> None:
             finally:
                 tmp.unlink(missing_ok=True)
 
+    class TestDisableReview(unittest.TestCase):
+        def setUp(self) -> None:
+            os.environ["PLANNING_DISABLE_REVDIFF"] = "1"
+
+        def tearDown(self) -> None:
+            os.environ.pop("PLANNING_DISABLE_REVDIFF", None)
+
+        def test_review_disabled_flag(self) -> None:
+            self.assertTrue(review_disabled())
+
+        def test_file_mode_no_output(self) -> None:
+            import io
+            tmp = Path(tempfile.mktemp(suffix=".md"))
+            tmp.write_text("# Plan\n- task 1\n")
+            buf, old = io.StringIO(), sys.stdout
+            sys.stdout = buf
+            try:
+                run_file_mode(tmp)
+            finally:
+                sys.stdout = old
+                tmp.unlink(missing_ok=True)
+            self.assertEqual(buf.getvalue(), "")
+
+        def test_hook_mode_ask(self) -> None:
+            import io
+            event = json.dumps({"tool_input": {"plan": "# Plan\n- task 1"}})
+            old_stdin, old_stdout = sys.stdin, sys.stdout
+            sys.stdin, buf = io.StringIO(event), io.StringIO()
+            sys.stdout = buf
+            try:
+                run_hook_mode()
+            finally:
+                sys.stdin, sys.stdout = old_stdin, old_stdout
+            out = json.loads(buf.getvalue())["hookSpecificOutput"]
+            self.assertEqual(out["permissionDecision"], "ask")
+            self.assertIn("disabled", out["permissionDecisionReason"])
+
     loader = unittest.TestLoader()
     suite = unittest.TestSuite()
-    for tc in [TestGetDiff, TestReadPlanFromStdin, TestResponses, TestFileMode]:
+    for tc in [TestGetDiff, TestReadPlanFromStdin, TestResponses, TestFileMode, TestDisableReview]:
         suite.addTests(loader.loadTestsFromTestCase(tc))
     runner = unittest.TextTestRunner(verbosity=2)
     result = runner.run(suite)

--- a/plugins/planning/scripts/plan-review-hook.py
+++ b/plugins/planning/scripts/plan-review-hook.py
@@ -97,6 +97,14 @@ def main() -> None:
         make_response("ask", "no plan content in hook event")
         return
 
+    # skip interactive review entirely when disabled (e.g. claude /remote-control, where
+    # a host terminal overlay would be invisible to the remote client and block the
+    # session). falls through to the normal ExitPlanMode confirmation, which the remote
+    # client can see and act on. covers both revdiff and the plan-annotate.py fallback.
+    if os.environ.get("PLANNING_DISABLE_REVDIFF"):
+        make_response("ask", "plan review disabled via PLANNING_DISABLE_REVDIFF")
+        return
+
     plugin_root = os.environ.get("CLAUDE_PLUGIN_ROOT", "")
     if not plugin_root:
         make_response("ask", "CLAUDE_PLUGIN_ROOT not set")

--- a/tests/test-planning-disable-review.sh
+++ b/tests/test-planning-disable-review.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+# tests for PLANNING_DISABLE_REVDIFF — skips interactive plan review on the
+# ExitPlanMode hook route and the launch-plan-review.sh launcher route, so a
+# remote client (claude /remote-control) is not blocked by a host-only overlay.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(dirname "$SCRIPT_DIR")"
+HOOK="$REPO_ROOT/plugins/planning/scripts/plan-review-hook.py"
+LAUNCHER="$REPO_ROOT/plugins/planning/scripts/launch-plan-review.sh"
+
+passed=0
+failed=0
+
+assert_contains() {
+    local test_name="$1" needle="$2" haystack="$3"
+    case "$haystack" in
+        *"$needle"*) echo "  PASS: $test_name"; passed=$((passed + 1)) ;;
+        *) echo "  FAIL: $test_name"; echo "    expected to contain: $needle"; echo "    actual: $(printf '%q' "$haystack")"; failed=$((failed + 1)) ;;
+    esac
+}
+
+assert_empty() {
+    local test_name="$1" actual="$2"
+    if [ -z "$actual" ]; then
+        echo "  PASS: $test_name"; passed=$((passed + 1))
+    else
+        echo "  FAIL: $test_name"; echo "    expected empty output"; echo "    actual: $(printf '%q' "$actual")"; failed=$((failed + 1))
+    fi
+}
+
+assert_rc() {
+    local test_name="$1" expected="$2" actual="$3"
+    if [ "$expected" = "$actual" ]; then
+        echo "  PASS: $test_name"; passed=$((passed + 1))
+    else
+        echo "  FAIL: $test_name"; echo "    expected rc: $expected, actual: $actual"; failed=$((failed + 1))
+    fi
+}
+
+echo "testing PLANNING_DISABLE_REVDIFF"
+echo "================================"
+
+# test 1: hook route returns an "ask" response with the disabled reason, without
+# needing CLAUDE_PLUGIN_ROOT or any overlay terminal (guard fires before both)
+echo ""
+echo "test 1: hook route skips review when disabled"
+event='{"tool_input":{"plan":"# Plan\n- task 1\n"}}'
+out="$(printf '%s' "$event" | PLANNING_DISABLE_REVDIFF=1 python3 "$HOOK" 2>/dev/null)"
+assert_contains "hook returns ask decision" '"permissionDecision": "ask"' "$out"
+assert_contains "hook reports disabled reason" "PLANNING_DISABLE_REVDIFF" "$out"
+
+# test 2: launcher route exits 0 with empty output (no overlay opened) when disabled
+echo ""
+echo "test 2: launcher skips overlay when disabled"
+PLAN_FILE="$(mktemp "${TMPDIR:-/tmp}/plan-review-test-XXXXXX")"
+printf '# Plan\n- task 1\n' > "$PLAN_FILE"
+lout="$(PLANNING_DISABLE_REVDIFF=1 bash "$LAUNCHER" "$PLAN_FILE" 2>/dev/null)"
+lrc=$?
+rm -f "$PLAN_FILE"
+assert_rc "launcher exits 0" 0 "$lrc"
+assert_empty "launcher produces no annotations" "$lout"
+
+# summary
+echo ""
+echo "================================"
+echo "results: $passed passed, $failed failed"
+
+if [ "$failed" -gt 0 ]; then
+    exit 1
+fi


### PR DESCRIPTION
Under `claude /remote-control` the plan-review overlay opened on the host terminal, which a mobile or web client cannot see or interact with. The `ExitPlanMode` hook runs `launch-plan-review.sh` synchronously with a 4-day timeout, so the overlay blocked the session indefinitely while the remote client showed nothing.

`PLANNING_DISABLE_REVDIFF=1` now skips interactive plan review entirely on both routes (the `ExitPlanMode` hook and `/planning:make`) and falls through to the normal `ExitPlanMode` confirmation, which the remote client can act on.

The reporter's suggested fallback to the `$EDITOR` path would not have helped: `plan-annotate.py` opens the same kind of host overlay (tmux/kitty/wezterm) keyed off the same env vars, so it hangs the same way. The flag guards all three chokepoints instead: `plan-review-hook.py`, `launch-plan-review.sh`, and the `plan-annotate.py` fallback.

Remote-control is not detectable from a hook. The CLI keeps running locally, host terminal env vars stay set, and there is no documented signal for it, so a static opt-out is the lever available. The variable is read when review fires, so export it before a session you may drive remotely.

Tests: 3 new `plan-annotate.py --test` cases plus a new `tests/test-planning-disable-review.sh` covering the hook and launcher routes.

Also bumps planning to 3.8.1 and fixes a stale `plan-annotate.py` path in the README (`hooks/` to `scripts/`).

Closes #32
