### PR TITLE
fix(planning): add agterm overlay to $EDITOR plan-review fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ This repo ships independent Claude Code plugins. Version headings use values fro
 
 Entries are sorted by plugin version date, newest first.
 
+## planning v3.8.2 - 2026-07-04
+
+### Bug Fixes
+
+- plan review `$EDITOR` fallback: add an `agterm` terminal backend to `plan-annotate.py`. In an agterm session with no `revdiff` installed, `open_editor()` only knew tmux/kitty/wezterm, so it fell through to a stray `KITTY_LISTEN_ON` and opened the editor in an invisible background kitty (or hung on the sentinel) instead of agterm. It now opens `$EDITOR` in a full-pane overlay via `agtermctl session overlay open --block` (checked before tmux/kitty, mirroring `launch-plan-review.sh`), toggling the session status indicator to blocked while up and restoring active on exit
+
 ## planning v3.8.1 - 2026-06-29
 
 ### Bug Fixes

--- a/README.md
+++ b/README.md
@@ -203,19 +203,19 @@ Structured implementation planning with interactive annotation review and autono
 - **Step 2** — creates the plan file with tasks, file lists, test requirements, and progress tracking
 - **Step 3** — offers interactive review (opens plan in `$EDITOR` via plan-annotate), auto review, start implementation, or done
 
-**plan-annotate.py** — interactive plan annotation tool. Opens plans in your `$EDITOR` via a terminal overlay (tmux popup, kitty overlay, or wezterm split-pane), lets you annotate directly, and feeds a unified diff back to Claude so it revises the plan. Two modes:
+**plan-annotate.py** — interactive plan annotation tool. Opens plans in your `$EDITOR` via a terminal overlay (agterm overlay, tmux popup, kitty overlay, or wezterm split-pane), lets you annotate directly, and feeds a unified diff back to Claude so it revises the plan. Two modes:
 
 - *Hook mode* (default) — intercepts `ExitPlanMode`, opens plan in editor, denies tool call with diff if changes made, forcing revision loop
 - *File mode* (`plan-annotate.py <plan-file>`) — outputs unified diff to stdout for integration with custom workflows
 
-Requirements: tmux, kitty, or wezterm terminal, `$EDITOR` (defaults to `micro`). **Kitty users** must enable remote control in `kitty.conf`:
+Requirements: agterm, tmux, kitty, or wezterm terminal (agterm tried first), `$EDITOR` (defaults to `micro`). **Agterm users**: needs `agtermctl` on PATH (bundled with agterm), no extra config. **Kitty users** must enable remote control in `kitty.conf`:
 
 ```
 allow_remote_control yes
 listen_on unix:/tmp/kitty-$KITTY_PID
 ```
 
-*Note*: when `revdiff` is installed, the `ExitPlanMode` hook and `/planning:make` interactive review both route through `launch-plan-review.sh` instead, which supports a wider set of overlays: agterm, tmux, zellij, herdr, kitty, wezterm/kaku, cmux, ghostty, iTerm2, and emacs vterm. The 3-terminal list above applies only to the `$EDITOR` fallback when revdiff is not installed.
+*Note*: when `revdiff` is installed, the `ExitPlanMode` hook and `/planning:make` interactive review both route through `launch-plan-review.sh` instead, which supports a wider set of overlays: agterm, tmux, zellij, herdr, kitty, wezterm/kaku, cmux, ghostty, iTerm2, and emacs vterm. The 4-terminal list above applies only to the `$EDITOR` fallback when revdiff is not installed.
 
 *Disabling review*: set `PLANNING_DISABLE_REVDIFF=1` to skip interactive plan review entirely on both routes (revdiff and the `$EDITOR` fallback). No overlay opens and the plan proceeds to the normal `ExitPlanMode` confirmation. This exists for remote clients (`claude /remote-control`): the overlay always opens on the host terminal, which a mobile or web client cannot see or interact with, so review would otherwise block the session. The variable is read when review fires, so export it in your shell before starting a session you may later drive remotely.
 

--- a/plugins/planning/.claude-plugin/plugin.json
+++ b/plugins/planning/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "planning",
   "description": "Structured implementation planning, interactive annotation review, and autonomous plan execution",
-  "version": "3.8.1",
+  "version": "3.8.2",
   "author": {
     "name": "Umputun"
   },

--- a/plugins/planning/scripts/plan-annotate.py
+++ b/plugins/planning/scripts/plan-annotate.py
@@ -4,7 +4,7 @@
 interactive plan review hook that lets you annotate Claude's plans directly
 in your editor before approving them. when Claude calls ExitPlanMode, this
 hook intercepts the call, opens the plan in $EDITOR via a terminal overlay
-(tmux or kitty), and waits for you to review/edit. if you make changes,
+(agterm, tmux, kitty, or wezterm), and waits for you to review/edit. if you make changes,
 the hook computes a unified diff and sends it back to Claude as a denial
 reason, forcing Claude to revise the plan based on your annotations. if
 you make no changes, the normal approval dialog appears.
@@ -26,16 +26,17 @@ returns PreToolUse hook JSON response with permissionDecision:
   - "deny" → changes detected, unified diff sent as denial reason
 
 requirements:
-  - tmux, kitty, or wezterm terminal (tmux tried first, then kitty, then wezterm)
+  - agterm, tmux, kitty, or wezterm terminal (agterm tried first, then tmux, kitty, wezterm)
   - $EDITOR set (defaults to micro)
+  - agterm users: needs agtermctl on PATH (bundled with agterm); no extra config
   - kitty users: kitty.conf must have allow_remote_control and listen_on configured:
       allow_remote_control yes
       listen_on unix:/tmp/kitty-$KITTY_PID
 
-terminal priority: tmux display-popup → kitty overlay → wezterm split-pane → error
+terminal priority: agterm overlay → tmux display-popup → kitty overlay → wezterm split-pane → error
 
 limitations:
-  - requires tmux, kitty, or wezterm - without any, returns error (no annotation)
+  - requires agterm, tmux, kitty, or wezterm - without any, returns error (no annotation)
   - does not work in plain terminals (iTerm2, Terminal.app, etc.)
   - kitty requires KITTY_LISTEN_ON env var (set by kitty when listen_on is configured)
   - the hook blocks until the editor closes; timeout should be set high
@@ -109,19 +110,52 @@ def get_diff(original: str, edited: str) -> str:
 
 
 def open_editor(filepath: Path, target_window: bool = True) -> int:
-    """open file in $EDITOR via tmux popup, kitty overlay, or wezterm split-pane, blocking until editor closes.
-    tries tmux first (if $TMUX is set), then kitty, then wezterm. returns non-zero if none is available.
+    """open file in $EDITOR via a terminal overlay, blocking until the editor closes.
+    tries agterm first (if $AGTERM_SESSION_ID is set), then tmux (if $TMUX), then kitty,
+    then wezterm. returns non-zero if none is available.
     when target_window is True (hook mode), targets the kitty window from KITTY_WINDOW_ID.
-    when False (file mode), opens in the currently focused window."""
+    when False (file mode), opens in the currently focused window. agterm always targets the
+    current session via $AGTERM_SESSION_ID, so target_window does not affect it."""
     editor = os.environ.get("EDITOR", "micro")
     # resolve the first token of $EDITOR to an absolute path so that
-    # sh -c (used by kitty/wezterm overlays) can find the binary even
-    # when /opt/homebrew/bin or similar dirs are not in sh's default PATH.
+    # sh -c (used by the agterm/kitty/wezterm overlays) can find the binary
+    # even when /opt/homebrew/bin or similar dirs are not in sh's default PATH.
     editor_parts = shlex.split(editor)
     resolved = shutil.which(editor_parts[0])
     if resolved:
         editor_parts[0] = resolved
     editor_cmd = " ".join(shlex.quote(p) for p in editor_parts)
+
+    # agterm: `agtermctl session overlay open <cmd> --block` opens the editor in a full-pane
+    # overlay over the agent's own session and blocks until it exits (like tmux's display-popup -E),
+    # so no sentinel is needed. checked first so an agterm session uses its native overlay even when
+    # a multiplexer OR a stray KITTY_LISTEN_ON is also present in the environment. needs
+    # $AGTERM_SESSION_ID (set in every agterm session) and agtermctl on PATH; passes $AGTERM_SOCKET
+    # so it reaches the agterm instance hosting this session. the command string is shell-interpreted
+    # by agterm, so the shell-quoted `editor_cmd` + filepath works. sets the session status indicator
+    # to blocked while the overlay is up and restores active on every exit path.
+    agterm_session = os.environ.get("AGTERM_SESSION_ID")
+    if agterm_session and shutil.which("agtermctl"):
+        target = ["--target", agterm_session]
+        agterm_socket = os.environ.get("AGTERM_SOCKET")
+        if agterm_socket:
+            target += ["--socket", agterm_socket]
+        overlay_cmd = f"{editor_cmd} {shlex.quote(str(filepath))}"
+        subprocess.run(
+            ["agtermctl", "session", "status", "blocked", "--blink", *target],
+            stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+        )
+        try:
+            subprocess.run(
+                ["agtermctl", "session", "overlay", "open", overlay_cmd, *target, "--block"],
+                stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+            )
+        finally:
+            subprocess.run(
+                ["agtermctl", "session", "status", "active", *target],
+                stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+            )
+        return 0
 
     # tmux: display-popup -E blocks until the command exits, no sentinel needed
     if os.environ.get("TMUX") and shutil.which("tmux"):
@@ -196,7 +230,7 @@ def run_file_mode(plan_file: Path) -> None:
 
     try:
         if open_editor(tmp_path, target_window=False) != 0:
-            print("error: no overlay terminal available (requires tmux, kitty, or wezterm)", file=sys.stderr)
+            print("error: no overlay terminal available (requires agterm, tmux, kitty, or wezterm)", file=sys.stderr)
             sys.exit(1)
 
         edited_content = tmp_path.read_text()
@@ -225,7 +259,7 @@ def run_hook_mode() -> None:
 
     try:
         if open_editor(tmp_path) != 0:
-            print(make_response("ask", "no overlay terminal available (requires tmux, kitty, or wezterm), skipping plan annotation"))
+            print(make_response("ask", "no overlay terminal available (requires agterm, tmux, kitty, or wezterm), skipping plan annotation"))
             return
 
         edited_content = tmp_path.read_text()

--- a/plugins/planning/scripts/plan-review-hook.py
+++ b/plugins/planning/scripts/plan-review-hook.py
@@ -14,7 +14,7 @@ requirements:
   - revdiff (preferred) or $EDITOR (fallback)
   - revdiff path: agterm, tmux, zellij, herdr, kitty, wezterm, kaku, cmux,
     ghostty, iTerm2, or emacs vterm
-  - $EDITOR fallback (plan-annotate.py): tmux, kitty, or wezterm
+  - $EDITOR fallback (plan-annotate.py): agterm, tmux, kitty, or wezterm
 """
 
 import json


### PR DESCRIPTION
plan-annotate.py's open_editor() (the $EDITOR fallback used when revdiff is not installed) only supported tmux, kitty, and wezterm. In an agterm session it had no native branch, so it fell through to a stray KITTY_LISTEN_ON and opened the editor in an invisible background kitty (or hung on the sentinel) instead of agterm.

Add an agterm branch, checked before tmux/kitty (mirroring launch-plan-review.sh): open $EDITOR in a full-pane overlay via `agtermctl session overlay open --block`, toggling the session status indicator to blocked while up and restoring active on exit. Docs, README, and the version (3.8.2) + changelog updated.