### PR TITLE
fix(review): add agterm overlay backend to git-review

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ This repo ships independent Claude Code plugins. Version headings use values fro
 
 Entries are sorted by plugin version date, newest first.
 
+## review v2.2.2 - 2026-07-09
+
+### Bug Fixes
+
+- git-review `$EDITOR` overlay: add an `agterm` terminal backend to `git-review.py`. In an agterm session `open_editor()` only knew tmux/kitty/wezterm, so it fell through to a stray `KITTY_LISTEN_ON` (opening the editor in an invisible background kitty) or errored out. It now opens `$EDITOR` in a full-pane overlay via `agtermctl session overlay open --block` (checked before tmux/kitty/wezterm, mirroring `planning`'s `plan-annotate.py`), toggling the session status indicator to blocked while up and restoring active on exit
+- git-review multi-word `$EDITOR`: fix `open_editor()` quoting the entire `$EDITOR` string as a single shell token, which made every overlay backend try to exec a binary literally named e.g. `emacsclient -c -a ''` and fail silently. `$EDITOR` is now `shlex.split` into argv with its first token resolved to an absolute path and each part re-quoted, so multi-word editors work across the agterm/tmux/kitty/wezterm paths
+
 ## planning v3.8.2 - 2026-07-04
 
 ### Bug Fixes

--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ PR review, interactive git diff annotation review, and writing style tools. Inst
 
 Uses `gh` CLI for all GitHub operations and git worktrees to avoid disrupting the current checkout.
 
-**git-review** — interactive annotation-based code review. Generates a cleaned-up diff, opens it in `$EDITOR` via tmux popup, kitty overlay, or wezterm split-pane. You annotate directly in the diff, and the script returns your changes as a git diff. Claude reads annotations, fixes code, regenerates the diff, and loops until you close the editor without changes. Supports auto-detection of uncommitted changes or branch diffs.
+**git-review** — interactive annotation-based code review. Generates a cleaned-up diff, opens it in `$EDITOR` via agterm overlay, tmux popup, kitty overlay, or wezterm split-pane (agterm tried first). You annotate directly in the diff, and the script returns your changes as a git diff. Claude reads annotations, fixes code, regenerates the diff, and loops until you close the editor without changes. Supports auto-detection of uncommitted changes or branch diffs. **Agterm users**: needs `agtermctl` on PATH (bundled with agterm), no extra config.
 
 Run tests: `python3 plugins/review/skills/git-review/scripts/git-review.py --test`
 

--- a/plugins/review/.claude-plugin/plugin.json
+++ b/plugins/review/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "review",
   "description": "PR review, interactive git diff annotation review, and writing style guide",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "author": {
     "name": "Umputun"
   },

--- a/plugins/review/skills/git-review/SKILL.md
+++ b/plugins/review/skills/git-review/SKILL.md
@@ -17,7 +17,7 @@ Interactive annotation-based code review using editor overlays.
 ## How It Works
 
 1. Script generates a cleaned-up diff file (friendly headers, no technical noise)
-2. Opens in `$EDITOR` via tmux popup, kitty overlay, or wezterm split-pane
+2. Opens in `$EDITOR` via agterm overlay, tmux popup, kitty overlay, or wezterm split-pane
 3. User adds annotations (comments, change requests) directly in the file
 4. Script returns user's annotations as a git diff
 5. Claude reads annotations, fixes code in the real repo
@@ -101,7 +101,8 @@ User: "review my changes"
 
 ## Requirements
 
-- tmux, kitty, or wezterm terminal (for editor overlay)
+- agterm, tmux, kitty, or wezterm terminal (for editor overlay)
 - `$EDITOR` set (defaults to micro)
 - git
+- agterm users: needs `agtermctl` on PATH (bundled with agterm); no extra config
 - kitty users: kitty.conf must have `allow_remote_control yes` and `listen_on unix:/tmp/kitty-$KITTY_PID`

--- a/plugins/review/skills/git-review/scripts/git-review.py
+++ b/plugins/review/skills/git-review/scripts/git-review.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """git-review.py - interactive git diff annotation tool.
 
-generates a cleaned-up diff file, opens it in $EDITOR via tmux/kitty/wezterm overlay,
+generates a cleaned-up diff file, opens it in $EDITOR via agterm/tmux/kitty/wezterm overlay,
 and tracks user annotations via a git repo in /tmp. returns the user's
 annotations (additions/edits) as a git diff on stdout.
 
@@ -20,9 +20,10 @@ each invocation regenerates the cleaned diff, commits it, opens the editor,
 and returns `git diff` output showing what the user changed.
 
 requirements:
-    - tmux, kitty, or wezterm terminal (tmux tried first, then kitty, then wezterm)
+    - agterm, tmux, kitty, or wezterm terminal (agterm tried first, then tmux, then kitty, then wezterm)
     - $EDITOR set (defaults to micro)
     - git
+    - agterm users: needs agtermctl on PATH (bundled with agterm); no extra config
     - kitty users: kitty.conf must have allow_remote_control and listen_on configured
 """
 
@@ -255,15 +256,51 @@ def setup_review_repo(review_dir: Path, content: str) -> None:
 
 
 def open_editor(filepath: Path) -> int:
-    """open file in $EDITOR via tmux popup, kitty overlay, or wezterm split-pane, blocking until editor closes.
-    tries tmux first (if $TMUX is set), then kitty, then wezterm. returns non-zero if none is available."""
+    """open file in $EDITOR via agterm overlay, tmux popup, kitty overlay, or wezterm split-pane,
+    blocking until editor closes. tries agterm first (if $AGTERM_SESSION_ID is set), then tmux
+    (if $TMUX), then kitty, then wezterm. returns non-zero if none is available."""
     editor = os.environ.get("EDITOR", "micro")
+    # $EDITOR may be multi-word (e.g. "emacsclient -c -a ''"); split to argv, resolve the
+    # first token to an absolute path (overlays' sh doesn't inherit /opt/homebrew/bin etc.),
+    # re-quote each part. quoting the whole string as one token would exec a bogus binary name.
+    editor_parts = shlex.split(editor) or ["micro"]  # guard set-but-empty $EDITOR
+    resolved = shutil.which(editor_parts[0])
+    if resolved:
+        editor_parts[0] = resolved
+    editor_cmd = " ".join(shlex.quote(p) for p in editor_parts)
+
+    # agterm: overlay open --block runs the editor full-pane and blocks (like tmux's -E), no
+    # sentinel needed. checked first so agterm wins over a stray KITTY_LISTEN_ON. needs
+    # $AGTERM_SESSION_ID + agtermctl; toggles session status blocked→active around the overlay.
+    agterm_session = os.environ.get("AGTERM_SESSION_ID")
+    if agterm_session and shutil.which("agtermctl"):
+        target = ["--target", agterm_session]
+        agterm_socket = os.environ.get("AGTERM_SOCKET")
+        if agterm_socket:
+            target += ["--socket", agterm_socket]
+        overlay_cmd = f"{editor_cmd} {shlex.quote(str(filepath))}"
+        subprocess.run(
+            ["agtermctl", "session", "status", "blocked", "--blink", *target],
+            stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+        )
+        try:
+            subprocess.run(
+                ["agtermctl", "session", "overlay", "open", overlay_cmd, *target, "--block"],
+                stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+            )
+        finally:
+            subprocess.run(
+                ["agtermctl", "session", "status", "active", *target],
+                stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+            )
+        return 0
 
     # tmux: display-popup -E blocks until the command exits, no sentinel needed
     if os.environ.get("TMUX") and shutil.which("tmux"):
         result = subprocess.run(
             ["tmux", "display-popup", "-E", "-w", "90%", "-h", "90%",
-             "-T", " Git Review ", "--", editor, str(filepath)],
+             "-T", " Git Review ", "--", "sh", "-c",
+             f"{editor_cmd} {shlex.quote(str(filepath))}"],
             stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
         )
         return result.returncode
@@ -278,7 +315,7 @@ def open_editor(filepath: Path) -> int:
         os.close(fd)
         os.unlink(sentinel_path)
         sentinel = Path(sentinel_path)
-        wrapper = f'{shlex.quote(editor)} {shlex.quote(str(filepath))}; touch {shlex.quote(str(sentinel))}'
+        wrapper = f'{editor_cmd} {shlex.quote(str(filepath))}; touch {shlex.quote(str(sentinel))}'
         cmd = ["kitty", "@", "--to", kitty_sock, "launch", "--type=overlay",
                f"--title=Git Review: {filepath.name}"]
         # target the kitty window where claude is running, not the active one
@@ -299,7 +336,7 @@ def open_editor(filepath: Path) -> int:
         os.close(fd)
         os.unlink(sentinel_path)
         sentinel = Path(sentinel_path)
-        wrapper = f'{shlex.quote(editor)} {shlex.quote(str(filepath))}; touch {shlex.quote(str(sentinel))}'
+        wrapper = f'{editor_cmd} {shlex.quote(str(filepath))}; touch {shlex.quote(str(sentinel))}'
         subprocess.run(
             ["wezterm", "cli", "split-pane", "--bottom", "--percent", "80",
              "--pane-id", wezterm_pane, "--", "sh", "-c", wrapper],
@@ -370,7 +407,7 @@ def run_review(base_ref: str | None = None, branch: str | None = None) -> None:
 
     review_file = review_dir / "review.diff"
     if open_editor(review_file) != 0:
-        print("error: no overlay terminal available (requires tmux, kitty, or wezterm)", file=sys.stderr)
+        print("error: no overlay terminal available (requires agterm, tmux, kitty, or wezterm)", file=sys.stderr)
         sys.exit(1)
 
     # get annotations


### PR DESCRIPTION
Fixes #35.

`git-review`'s `open_editor()` only supported tmux/kitty/wezterm. In an agterm session none match, so it fell through to a stray `KITTY_LISTEN_ON` (editor opens in an invisible background kitty) or errored with "no overlay terminal available". `planning`'s `plan-annotate.py` and `revdiff` already support agterm — `git-review` didn't.

## Changes

- Add an agterm backend to `open_editor()`, checked before tmux/kitty/wezterm, mirroring `plan-annotate.py`: `agtermctl session overlay open <cmd> --block`, toggling session status blocked→active around the overlay.
- Fix multi-word `$EDITOR`: the whole string was quoted as one shell token (`shlex.quote(editor)`), so `EDITOR="emacsclient -c -a ''"` made every backend try to exec a binary literally named `emacsclient -c -a ''` and fail silently. Now `shlex.split` + resolve first token to an absolute path + re-quote each part. Applied across all backends.
- Bump `review` 2.2.1 → 2.2.2, update README/SKILL/CHANGELOG.

## Testing

- `python3 plugins/review/skills/git-review/scripts/git-review.py --test` — 14 passed.
- Verified live in an agterm session: overlay opens full-pane and blocks until closed.

Note: `emacsclient -c` opens a GUI frame, so it won't render inside the terminal overlay regardless — that's editor config (`-t` for a terminal frame), not a plugin bug.
