### PR TITLE
feat(planning): configurable model for exec subagents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ This repo ships independent Claude Code plugins. Version headings use values fro
 
 Entries are sorted by plugin version date, newest first.
 
+## planning v3.9.0 - 2026-07-22
+
+### New Features
+
+- exec: subagent model is now configurable, so the orchestrator can stay on a cheap or usage-limited model while well-defined subagent work runs on a stronger one — e.g. orchestrate on Fable, run subagents on Opus. `subagent_model` sets the fallback for every subagent; `work_model` (task, fixer, finalizer, stats) and `review_model` (5 review specialists, smells) override it per tier. All empty (default) keeps the previous behavior of inheriting the orchestrator's model. Does not affect the external codex review, which runs through `run-codex.sh`
+
 ## planning v3.8.4 - 2026-07-12
 
 ### Bug Fixes

--- a/README.md
+++ b/README.md
@@ -281,6 +281,9 @@ Configuration via `userConfig` (prompted at plugin install):
 | `review_iterations` | `5` | Max fix-and-recheck cycles during internal review |
 | `external_review_iterations` | `10` | Max iterations for external review adversarial loop |
 | `finalize_enabled` | `true` | Whether to run the finalize phase (rebase + squash) |
+| `subagent_model` | *(empty — inherit orchestrator model)* | Fallback model for all exec subagents (e.g. `opus`), so the orchestrator can stay on a cheaper model |
+| `work_model` | *(empty — use `subagent_model`)* | Model for code-writing subagents (task, fixer, finalizer) and stats |
+| `review_model` | *(empty — use `subagent_model`)* | Model for read-only review subagents (5 specialists, smells) |
 | `plans_dir` | `docs/plans` | Directory where plan files are located |
 
 Environment variables read by `run-codex.sh`:

--- a/plugins/planning/.claude-plugin/plugin.json
+++ b/plugins/planning/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "planning",
   "description": "Structured implementation planning, interactive annotation review, and autonomous plan execution",
-  "version": "3.8.4",
+  "version": "3.9.0",
   "author": {
     "name": "Umputun"
   },
@@ -38,6 +38,24 @@
       "type": "boolean",
       "description": "Whether to run the finalize phase (rebase and squash commits).",
       "default": true
+    },
+    "subagent_model": {
+      "title": "Subagent model",
+      "type": "string",
+      "description": "Fallback model for all exec subagents, e.g. opus, sonnet, haiku. Leave empty to inherit the orchestrator's model.",
+      "default": ""
+    },
+    "work_model": {
+      "title": "Work subagent model",
+      "type": "string",
+      "description": "Model for code-writing subagents (task, fixer, finalizer) and stats. Leave empty to use subagent_model.",
+      "default": ""
+    },
+    "review_model": {
+      "title": "Review subagent model",
+      "type": "string",
+      "description": "Model for read-only review subagents (quality, implementation, testing, simplification, documentation, smells). Leave empty to use subagent_model.",
+      "default": ""
     },
     "plans_dir": {
       "title": "Plans directory",

--- a/plugins/planning/references/usage.md
+++ b/plugins/planning/references/usage.md
@@ -54,6 +54,9 @@ Set via `userConfig` in plugin.json (prompted at install):
 | `review_iterations` | `5` | max fix-and-recheck cycles |
 | `external_review_iterations` | `10` | max external review iterations |
 | `finalize_enabled` | `true` | run rebase + squash phase |
+| `subagent_model` | *(inherit)* | fallback model for all exec subagents, e.g. `opus` |
+| `work_model` | *(use `subagent_model`)* | model for task, fixer, finalizer, stats |
+| `review_model` | *(use `subagent_model`)* | model for review + smells agents |
 | `plans_dir` | `docs/plans` | directory for plan files |
 
 ### Customization

--- a/plugins/planning/skills/exec/SKILL.md
+++ b/plugins/planning/skills/exec/SKILL.md
@@ -25,7 +25,7 @@ The script checks project overrides, user overrides, and bundled defaults automa
 
 After reading a prompt file, replace ALL placeholders with actual values before passing to a subagent. Subagents run in fresh contexts without plugin env vars.
 
-Always substitute: `PLAN_FILE_PATH`, `PROGRESS_FILE_PATH`, `DEFAULT_BRANCH`, `${CLAUDE_PLUGIN_ROOT}` (resolve to actual absolute path), `RESOLVE_SCRIPT` (absolute path to `${CLAUDE_PLUGIN_ROOT}/skills/exec/scripts/resolve-file.sh`), `PLUGIN_DATA_DIR` (resolved `${CLAUDE_PLUGIN_DATA}` path — passed as second argument to resolve-file.sh so it can find user overrides), `USER_RULES` (resolved custom rules content from the rules loading step, or empty string if no rules found), and phase-specific values (`FINDINGS_LIST`, `REVIEW_PHASE`, `DIFF_COMMAND`).
+Always substitute: `PLAN_FILE_PATH`, `PROGRESS_FILE_PATH`, `DEFAULT_BRANCH`, `${CLAUDE_PLUGIN_ROOT}` (resolve to actual absolute path), `RESOLVE_SCRIPT` (absolute path to `${CLAUDE_PLUGIN_ROOT}/skills/exec/scripts/resolve-file.sh`), `PLUGIN_DATA_DIR` (resolved `${CLAUDE_PLUGIN_DATA}` path — passed as second argument to resolve-file.sh so it can find user overrides), `USER_RULES` (resolved custom rules content from the rules loading step, or empty string if no rules found), `SUBAGENT_MODEL` (in `prompts/review.md`: the resolved `REVIEW_MODEL`, or empty string), and phase-specific values (`FINDINGS_LIST`, `REVIEW_PHASE`, `DIFF_COMMAND`).
 
 ## Custom Rules Loading
 
@@ -36,6 +36,17 @@ bash ${CLAUDE_PLUGIN_ROOT}/scripts/resolve-rules.sh planning-rules.md ${CLAUDE_P
 ```
 
 If the output is non-empty, store it as the resolved custom rules content. When substituting `USER_RULES` in task prompts, wrap the content with a label so the subagent understands it: use "ADDITIONAL CUSTOM RULES:\n<content>" as the substitution. If the output is empty, substitute an empty string for `USER_RULES`. See `${CLAUDE_PLUGIN_ROOT}/references/custom-rules.md` for full documentation on the rules mechanism.
+
+## Subagent Model
+
+Subagents split into two tiers, each with its own userConfig, both falling back to `subagent_model`:
+
+- **work tier** — `work_model`, falling back to `subagent_model`. Applies to the task subagents (step 6), every fixer (steps 7-10), the finalizer (step 11), and the stats agent (step 12).
+- **review tier** — `review_model`, falling back to `subagent_model`. Applies to the read-only review agents launched from `prompts/review.md` (steps 7 and 10) and the smells agent (step 8).
+
+Resolve both once at the start: `WORK_MODEL` = `work_model` if non-empty else `subagent_model`; `REVIEW_MODEL` = `review_model` if non-empty else `subagent_model`. On each Agent tool call, pass `model: <resolved value for that tier>` when it is non-empty; omit `model` entirely when it is empty so the subagent inherits the orchestrator's model.
+
+This lets the orchestrator run on a cheap/limited model while well-defined subagent work runs on a stronger one (e.g. orchestrator on Fable, subagents on Opus). It applies to Agent tool calls only — the external review in step 9 runs through `run-codex.sh` and is unaffected.
 
 ## Process
 
@@ -155,6 +166,7 @@ Repeat until no `[ ]` checkboxes remain in any Task section:
 5. **Spawn a subagent** using Agent tool with:
    - `mode: "bypassPermissions"`
    - `subagent_type: "general-purpose"`
+   - `model: <WORK_MODEL>` when resolved non-empty (see Subagent Model)
    - The task prompt from `prompts/task.md`, with all placeholders substituted as described in the Placeholder Substitution section above (including `USER_RULES`)
 6. **After subagent returns**, re-read the plan file and check if that task's checkboxes are now `[x]`
    - If yes — task succeeded, continue loop
@@ -177,7 +189,7 @@ Report to user: "--- Review phase 1: comprehensive ---"
 
 Loop up to `review_iterations` times (userConfig, default: 5). Track the current iteration number:
 
-1. **Read review.md as a playbook (NOT as a subagent prompt)** — resolve `prompts/review.md` through the override chain and read it from this main session. It tells YOU (the orchestrator) which specialist agents to fan out for the current `REVIEW_PHASE`. Substitute `DEFAULT_BRANCH`, `PLAN_FILE_PATH`, `PROGRESS_FILE_PATH`, `${CLAUDE_PLUGIN_ROOT}`, and `REVIEW_PHASE` in the resolved content. Then follow the playbook FROM THIS SESSION: launch the specified Agent tool calls in a single message for parallel execution. Subagents do not have Agent tool access, so the fanout MUST be initiated from the main orchestrator.
+1. **Read review.md as a playbook (NOT as a subagent prompt)** — resolve `prompts/review.md` through the override chain and read it from this main session. It tells YOU (the orchestrator) which specialist agents to fan out for the current `REVIEW_PHASE`. Substitute `DEFAULT_BRANCH`, `PLAN_FILE_PATH`, `PROGRESS_FILE_PATH`, `${CLAUDE_PLUGIN_ROOT}`, `REVIEW_PHASE`, and `SUBAGENT_MODEL` in the resolved content. Then follow the playbook FROM THIS SESSION: launch the specified Agent tool calls in a single message for parallel execution. Subagents do not have Agent tool access, so the fanout MUST be initiated from the main orchestrator.
    - **Iteration 1**: set `REVIEW_PHASE` to `comprehensive`. Per the playbook, launch 5 parallel review agents (quality, implementation, testing, simplification, documentation).
    - **Iteration 2 and later**: set `REVIEW_PHASE` to `critical`. Per the playbook, launch 2 parallel review agents (quality, implementation) focused on critical/major issues only. Before this iteration, report to user: "--- Review phase 1: critical re-check (iteration N) ---"
 
@@ -199,7 +211,7 @@ Report to user: "--- Review phase 2: code smells analysis ---"
 
 Run once (no loop):
 
-1. **Spawn a smells agent** — resolve `agents/smells.txt` through the override chain. Launch one Agent tool call with `mode: "bypassPermissions"`, `subagent_type: "general-purpose"`, and the resolved agent prompt.
+1. **Spawn a smells agent** — resolve `agents/smells.txt` through the override chain. Launch one Agent tool call with `mode: "bypassPermissions"`, `subagent_type: "general-purpose"`, `model: <REVIEW_MODEL>` when non-empty, and the resolved agent prompt.
 
 2. **Collect findings** — after the agent returns, report to user with a compact list of findings (one line per finding). Log findings to progress file:
    `bash ${CLAUDE_PLUGIN_ROOT}/skills/exec/scripts/append-progress.sh <progress-file> "review phase 2: findings"`
@@ -298,6 +310,7 @@ When stats summary is done (or skipped on failure):
 - NEVER summarize or filter agent findings — pass the full output to the fixer agent verbatim
 - All prompt and agent files MUST be resolved through the three-layer override chain before use
 - All `subagent_type` values must be `general-purpose` — agent files provide the specialized prompt
+- Every Agent tool call passes `model` from its tier — `WORK_MODEL` for task/fixer/finalizer/stats, `REVIEW_MODEL` for review and smells agents — and omits `model` when the resolved value is empty (see Subagent Model)
 - After reading a prompt file, substitute all placeholders before passing to subagent (see Placeholder Substitution)
 - Subagents run with NO human available — they must NEVER ask the user a question (no AskUserQuestion, no pausing for input). They decide judgment calls the plan does not settle from the project's lint rules, CLAUDE.md, and code conventions, and log each as a `[decision]`/`[deviation]` line for the completion report
 - In worktree mode (`worktree_mode = true`) the main working directory is never touched — no branch is created or checked out there and no changes land there; all git operations run inside the worktree, and Step 4's create-branch.sh is skipped

--- a/plugins/planning/skills/exec/references/prompts/review.md
+++ b/plugins/planning/skills/exec/references/prompts/review.md
@@ -45,7 +45,7 @@ Read the progress file at PROGRESS_FILE_PATH for context on previous review iter
 
 Tag every finding with severity (CRITICAL/MAJOR/MINOR) and format each on its own line as: `SEVERITY: file:line — description`."
 
-In your next assistant response, emit 5 Agent tool_use blocks together. Each with `mode: "bypassPermissions"`, `subagent_type: "general-purpose"`, and the assembled prompt for one of the 5 specialists (quality, implementation, testing, simplification, documentation).
+In your next assistant response, emit 5 Agent tool_use blocks together. Each with `mode: "bypassPermissions"`, `subagent_type: "general-purpose"`, and the assembled prompt for one of the 5 specialists (quality, implementation, testing, simplification, documentation). If `SUBAGENT_MODEL` is non-empty, also pass `model: SUBAGENT_MODEL` on each block; if empty, omit `model`.
 
 After ALL 5 agents return, produce a STRICT bullet-list report — no prose summary, no narrative, no "agents converge on" sentences. Format requirements:
 
@@ -67,7 +67,7 @@ Resolve only `quality.txt` and `implementation.txt` using the resolve script. Re
 
 "Report ONLY critical and major issues — bugs, security vulnerabilities, data loss risks, broken functionality, incorrect logic, missing critical error handling. Ignore style, minor improvements, suggestions. Tag every reported finding with severity (CRITICAL or MAJOR) and format each on its own line as: `SEVERITY: file:line — description`."
 
-In your next assistant response, emit 2 Agent tool_use blocks together. Same `mode` and `subagent_type` as comprehensive mode.
+In your next assistant response, emit 2 Agent tool_use blocks together. Same `mode`, `subagent_type`, and `SUBAGENT_MODEL` handling as comprehensive mode.
 
 After BOTH agents return, produce the same STRICT bullet-list report as comprehensive mode (groupings by severity, exact bullet shape, agent attribution preserved, no prose summary). Additional rule for this mode:
 


### PR DESCRIPTION
`/planning:exec` spawns every subagent with the orchestrator's model — there's no way to run the orchestrator on one model and the subagents on another.

That matters now that Fable is out with a ~50% usage quota. Fable is a good fit for the parts of `exec` that need judgment and context — reading the plan, sequencing tasks, deciding when a phase is done — but that's a small share of the tokens. The bulk goes to task subagents, fixers, and the 5-specialist review fanout, which work from a fully specified prompt in a fresh context. That work doesn't need the scarce quota; Opus handles it. Today running `exec` from a Fable session burns Fable quota on all of it.

## Changes

- `subagent_model` userConfig — fallback model for every `exec` subagent.
- `work_model` (task, fixer, finalizer, stats) and `review_model` (5 review specialists, smells) — per-tier overrides, each falling back to `subagent_model`.
- `SKILL.md`: new "Subagent Model" section resolves `WORK_MODEL`/`REVIEW_MODEL` once at start; call sites and the key rules reference their tier.
- `prompts/review.md`: `SUBAGENT_MODEL` placeholder so the fanout playbook tags its Agent blocks. The orchestrator substitutes the resolved `REVIEW_MODEL` there, so existing user overrides of `review.md` keep working unchanged.
- Bump planning 3.8.4 → 3.9.0, update README, `references/usage.md`, CHANGELOG.

Two things deliberately left alone:

- The codex phase (step 9) runs through `run-codex.sh`, not the Agent tool, so `external_review_cmd` stays the knob there.
- The split is two tiers, not per-phase keys. Work vs read-only review is the line worth drawing; more keys is more config surface for little gain.

Stats went into the work tier. It's a read-only log aggregator, so review tier is arguable — happy to move it.

## Testing

- All defaults empty → `model` is omitted on every Agent call, same behavior as before.
- `bash tests/test-*.sh` — 5 passed.
- `python3 plugins/planning/scripts/plan-annotate.py --test` — OK.
- Docs-only change to `exec`; no scripts touched.