### PR TITLE
agterm: scope overlays to the active pane in split sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ PR review, interactive git diff annotation review, and writing style tools. Inst
 
 Uses `gh` CLI for all GitHub operations and git worktrees to avoid disrupting the current checkout.
 
-**git-review** — interactive annotation-based code review. Generates a cleaned-up diff, opens it in `$EDITOR` via agterm overlay, tmux popup, kitty overlay, or wezterm split-pane (agterm tried first). You annotate directly in the diff, and the script returns your changes as a git diff. Claude reads annotations, fixes code, regenerates the diff, and loops until you close the editor without changes. Supports auto-detection of uncommitted changes or branch diffs. **Agterm users**: needs `agtermctl` on PATH (bundled with agterm), no extra config.
+**git-review** — interactive annotation-based code review. Generates a cleaned-up diff, opens it in `$EDITOR` via agterm overlay, tmux popup, kitty overlay, or wezterm split-pane (agterm tried first). You annotate directly in the diff, and the script returns your changes as a git diff. Claude reads annotations, fixes code, regenerates the diff, and loops until you close the editor without changes. Supports auto-detection of uncommitted changes or branch diffs. **Agterm users**: needs `agtermctl` on PATH (bundled with agterm 0.20.0+), no extra config.
 
 Run tests: `python3 plugins/review/skills/git-review/scripts/git-review.py --test`
 
@@ -208,7 +208,7 @@ Structured implementation planning with interactive annotation review and autono
 - *Hook mode* (default) — intercepts `ExitPlanMode`, opens plan in editor, denies tool call with diff if changes made, forcing revision loop
 - *File mode* (`plan-annotate.py <plan-file>`) — outputs unified diff to stdout for integration with custom workflows
 
-Requirements: agterm, tmux, kitty, or wezterm terminal (agterm tried first), `$EDITOR` (defaults to `vi`). **Agterm users**: needs `agtermctl` on PATH (bundled with agterm), no extra config. **Kitty users** must enable remote control in `kitty.conf`:
+Requirements: agterm, tmux, kitty, or wezterm terminal (agterm tried first), `$EDITOR` (defaults to `vi`). **Agterm users**: needs `agtermctl` on PATH (bundled with agterm 0.20.0+), no extra config. **Kitty users** must enable remote control in `kitty.conf`:
 
 ```
 allow_remote_control yes

--- a/plugins/planning/scripts/launch-plan-review.sh
+++ b/plugins/planning/scripts/launch-plan-review.sh
@@ -63,11 +63,15 @@ POPUP_H="${REVDIFF_POPUP_HEIGHT:-90%}"
 if [ -n "${AGTERM_SESSION_ID:-}" ] && command -v agtermctl >/dev/null 2>&1; then
     AGTERM_TARGET=(--target "$AGTERM_SESSION_ID")
     [ -n "${AGTERM_SOCKET:-}" ] && AGTERM_TARGET+=(--socket "$AGTERM_SOCKET")
+    # scope to the active pane so the sibling pane stays live in a split session;
+    # $AGTERM_PANE is "left" on non-split sessions, so --pane is always safe to pass
+    AGTERM_PANE_ARG=()
+    [ -n "${AGTERM_PANE:-}" ] && AGTERM_PANE_ARG=(--pane "$AGTERM_PANE")
     agtermctl session status blocked --blink "${AGTERM_TARGET[@]}" >/dev/null 2>&1 || true
     trap 'agtermctl session status active "${AGTERM_TARGET[@]}" >/dev/null 2>&1 || true; rm -f "$OUTPUT_FILE"' EXIT
     trap 'exit 130' INT
     trap 'exit 143' TERM
-    agtermctl session overlay open "$REVDIFF_CMD" "${AGTERM_TARGET[@]}" --cwd "$CWD" --block >/dev/null || true
+    agtermctl session overlay open "$REVDIFF_CMD" "${AGTERM_TARGET[@]}" "${AGTERM_PANE_ARG[@]}" --cwd "$CWD" --block >/dev/null || true
     cat "$OUTPUT_FILE"
     exit 0
 fi

--- a/plugins/planning/scripts/launch-plan-review.sh
+++ b/plugins/planning/scripts/launch-plan-review.sh
@@ -63,14 +63,15 @@ POPUP_H="${REVDIFF_POPUP_HEIGHT:-90%}"
 if [ -n "${AGTERM_SESSION_ID:-}" ] && command -v agtermctl >/dev/null 2>&1; then
     AGTERM_TARGET=(--target "$AGTERM_SESSION_ID")
     [ -n "${AGTERM_SOCKET:-}" ] && AGTERM_TARGET+=(--socket "$AGTERM_SOCKET")
-    # scope status and overlay to the active pane so the sibling pane stays live in a split session;
-    # $AGTERM_PANE is "left" on non-split sessions, so --pane is always safe to pass
+    # scope status and overlay to the active pane so the sibling pane stays live in a split session.
+    # session status accepts left|right|scratch; overlay open only accepts left|right (a scratch
+    # pane falls back to full-session overlay).
     AGTERM_STATUS=(session status blocked --blink "${AGTERM_TARGET[@]}")
     AGTERM_OVERLAY=(session overlay open "$REVDIFF_CMD" "${AGTERM_TARGET[@]}")
-    if [ -n "${AGTERM_PANE:-}" ]; then
-        AGTERM_STATUS+=(--pane "$AGTERM_PANE")
-        AGTERM_OVERLAY+=(--pane "$AGTERM_PANE")
-    fi
+    [ -n "${AGTERM_PANE:-}" ] && AGTERM_STATUS+=(--pane "$AGTERM_PANE")
+    case "${AGTERM_PANE:-}" in
+        left|right) AGTERM_OVERLAY+=(--pane "$AGTERM_PANE") ;;
+    esac
     AGTERM_OVERLAY+=(--cwd "$CWD" --block)
     agtermctl "${AGTERM_STATUS[@]}" >/dev/null 2>&1 || true
     trap 'agtermctl session status active "${AGTERM_TARGET[@]}" >/dev/null 2>&1 || true; rm -f "$OUTPUT_FILE"' EXIT

--- a/plugins/planning/scripts/launch-plan-review.sh
+++ b/plugins/planning/scripts/launch-plan-review.sh
@@ -63,15 +63,20 @@ POPUP_H="${REVDIFF_POPUP_HEIGHT:-90%}"
 if [ -n "${AGTERM_SESSION_ID:-}" ] && command -v agtermctl >/dev/null 2>&1; then
     AGTERM_TARGET=(--target "$AGTERM_SESSION_ID")
     [ -n "${AGTERM_SOCKET:-}" ] && AGTERM_TARGET+=(--socket "$AGTERM_SOCKET")
-    # scope to the active pane so the sibling pane stays live in a split session;
+    # scope status and overlay to the active pane so the sibling pane stays live in a split session;
     # $AGTERM_PANE is "left" on non-split sessions, so --pane is always safe to pass
-    AGTERM_PANE_ARG=()
-    [ -n "${AGTERM_PANE:-}" ] && AGTERM_PANE_ARG=(--pane "$AGTERM_PANE")
-    agtermctl session status blocked --blink "${AGTERM_TARGET[@]}" >/dev/null 2>&1 || true
+    AGTERM_STATUS=(session status blocked --blink "${AGTERM_TARGET[@]}")
+    AGTERM_OVERLAY=(session overlay open "$REVDIFF_CMD" "${AGTERM_TARGET[@]}")
+    if [ -n "${AGTERM_PANE:-}" ]; then
+        AGTERM_STATUS+=(--pane "$AGTERM_PANE")
+        AGTERM_OVERLAY+=(--pane "$AGTERM_PANE")
+    fi
+    AGTERM_OVERLAY+=(--cwd "$CWD" --block)
+    agtermctl "${AGTERM_STATUS[@]}" >/dev/null 2>&1 || true
     trap 'agtermctl session status active "${AGTERM_TARGET[@]}" >/dev/null 2>&1 || true; rm -f "$OUTPUT_FILE"' EXIT
     trap 'exit 130' INT
     trap 'exit 143' TERM
-    agtermctl session overlay open "$REVDIFF_CMD" "${AGTERM_TARGET[@]}" "${AGTERM_PANE_ARG[@]}" --cwd "$CWD" --block >/dev/null || true
+    agtermctl "${AGTERM_OVERLAY[@]}" >/dev/null || true
     cat "$OUTPUT_FILE"
     exit 0
 fi

--- a/plugins/planning/scripts/plan-annotate.py
+++ b/plugins/planning/scripts/plan-annotate.py
@@ -28,7 +28,7 @@ returns PreToolUse hook JSON response with permissionDecision:
 requirements:
   - agterm, tmux, kitty, or wezterm terminal (agterm tried first, then tmux, kitty, wezterm)
   - $EDITOR set (defaults to vi)
-  - agterm users: needs agtermctl on PATH (bundled with agterm); no extra config
+  - agterm users: needs agtermctl on PATH (bundled with agterm 0.20.0+); no extra config
   - kitty users: kitty.conf must have allow_remote_control and listen_on configured:
       allow_remote_control yes
       listen_on unix:/tmp/kitty-$KITTY_PID
@@ -150,17 +150,19 @@ def open_editor(filepath: Path, target_window: bool = True) -> int:
         agterm_socket = os.environ.get("AGTERM_SOCKET")
         if agterm_socket:
             target += ["--socket", agterm_socket]
-        # scope to the active pane so the sibling stays live in a split session
+        # scope status and overlay to the active pane so the sibling stays live in a split session.
+        # session status accepts left|right|scratch; overlay open only accepts left|right
         agterm_pane = os.environ.get("AGTERM_PANE")
-        pane_args = ["--pane", agterm_pane] if agterm_pane else []
+        status_pane_args = ["--pane", agterm_pane] if agterm_pane else []
+        overlay_pane_args = ["--pane", agterm_pane] if agterm_pane in ("left", "right") else []
         overlay_cmd = f"{editor_cmd} {shlex.quote(str(filepath))}"
         subprocess.run(
-            ["agtermctl", "session", "status", "blocked", "--blink", *target, *pane_args],
+            ["agtermctl", "session", "status", "blocked", "--blink", *target, *status_pane_args],
             stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
         )
         try:
             subprocess.run(
-                ["agtermctl", "session", "overlay", "open", overlay_cmd, *target, *pane_args, "--block"],
+                ["agtermctl", "session", "overlay", "open", overlay_cmd, *target, *overlay_pane_args, "--block"],
                 stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
             )
         finally:

--- a/plugins/planning/scripts/plan-annotate.py
+++ b/plugins/planning/scripts/plan-annotate.py
@@ -150,6 +150,9 @@ def open_editor(filepath: Path, target_window: bool = True) -> int:
         agterm_socket = os.environ.get("AGTERM_SOCKET")
         if agterm_socket:
             target += ["--socket", agterm_socket]
+        # scope to the active pane so the sibling stays live in a split session
+        agterm_pane = os.environ.get("AGTERM_PANE")
+        pane_args = ["--pane", agterm_pane] if agterm_pane else []
         overlay_cmd = f"{editor_cmd} {shlex.quote(str(filepath))}"
         subprocess.run(
             ["agtermctl", "session", "status", "blocked", "--blink", *target],
@@ -157,7 +160,7 @@ def open_editor(filepath: Path, target_window: bool = True) -> int:
         )
         try:
             subprocess.run(
-                ["agtermctl", "session", "overlay", "open", overlay_cmd, *target, "--block"],
+                ["agtermctl", "session", "overlay", "open", overlay_cmd, *target, *pane_args, "--block"],
                 stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
             )
         finally:

--- a/plugins/planning/scripts/plan-annotate.py
+++ b/plugins/planning/scripts/plan-annotate.py
@@ -155,7 +155,7 @@ def open_editor(filepath: Path, target_window: bool = True) -> int:
         pane_args = ["--pane", agterm_pane] if agterm_pane else []
         overlay_cmd = f"{editor_cmd} {shlex.quote(str(filepath))}"
         subprocess.run(
-            ["agtermctl", "session", "status", "blocked", "--blink", *target],
+            ["agtermctl", "session", "status", "blocked", "--blink", *target, *pane_args],
             stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
         )
         try:

--- a/plugins/review/skills/git-review/SKILL.md
+++ b/plugins/review/skills/git-review/SKILL.md
@@ -104,5 +104,5 @@ User: "review my changes"
 - agterm, tmux, kitty, or wezterm terminal (for editor overlay)
 - `$EDITOR` set (defaults to vi)
 - git
-- agterm users: needs `agtermctl` on PATH (bundled with agterm); no extra config
+- agterm users: needs `agtermctl` on PATH (bundled with agterm 0.20.0+); no extra config
 - kitty users: kitty.conf must have `allow_remote_control yes` and `listen_on unix:/tmp/kitty-$KITTY_PID`

--- a/plugins/review/skills/git-review/scripts/git-review.py
+++ b/plugins/review/skills/git-review/scripts/git-review.py
@@ -293,7 +293,7 @@ def open_editor(filepath: Path) -> int:
         pane_args = ["--pane", agterm_pane] if agterm_pane else []
         overlay_cmd = f"{editor_cmd} {shlex.quote(str(filepath))}"
         subprocess.run(
-            ["agtermctl", "session", "status", "blocked", "--blink", *target],
+            ["agtermctl", "session", "status", "blocked", "--blink", *target, *pane_args],
             stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
         )
         try:

--- a/plugins/review/skills/git-review/scripts/git-review.py
+++ b/plugins/review/skills/git-review/scripts/git-review.py
@@ -288,6 +288,9 @@ def open_editor(filepath: Path) -> int:
         agterm_socket = os.environ.get("AGTERM_SOCKET")
         if agterm_socket:
             target += ["--socket", agterm_socket]
+        # scope to the active pane so the sibling stays live in a split session
+        agterm_pane = os.environ.get("AGTERM_PANE")
+        pane_args = ["--pane", agterm_pane] if agterm_pane else []
         overlay_cmd = f"{editor_cmd} {shlex.quote(str(filepath))}"
         subprocess.run(
             ["agtermctl", "session", "status", "blocked", "--blink", *target],
@@ -295,7 +298,7 @@ def open_editor(filepath: Path) -> int:
         )
         try:
             subprocess.run(
-                ["agtermctl", "session", "overlay", "open", overlay_cmd, *target, "--block"],
+                ["agtermctl", "session", "overlay", "open", overlay_cmd, *target, *pane_args, "--block"],
                 stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
             )
         finally:

--- a/plugins/review/skills/git-review/scripts/git-review.py
+++ b/plugins/review/skills/git-review/scripts/git-review.py
@@ -23,7 +23,7 @@ requirements:
     - agterm, tmux, kitty, or wezterm terminal (agterm tried first, then tmux, then kitty, then wezterm)
     - $EDITOR set (defaults to vi)
     - git
-    - agterm users: needs agtermctl on PATH (bundled with agterm); no extra config
+    - agterm users: needs agtermctl on PATH (bundled with agterm 0.20.0+); no extra config
     - kitty users: kitty.conf must have allow_remote_control and listen_on configured
 """
 
@@ -288,17 +288,19 @@ def open_editor(filepath: Path) -> int:
         agterm_socket = os.environ.get("AGTERM_SOCKET")
         if agterm_socket:
             target += ["--socket", agterm_socket]
-        # scope to the active pane so the sibling stays live in a split session
+        # scope status and overlay to the active pane so the sibling stays live in a split session.
+        # session status accepts left|right|scratch; overlay open only accepts left|right
         agterm_pane = os.environ.get("AGTERM_PANE")
-        pane_args = ["--pane", agterm_pane] if agterm_pane else []
+        status_pane_args = ["--pane", agterm_pane] if agterm_pane else []
+        overlay_pane_args = ["--pane", agterm_pane] if agterm_pane in ("left", "right") else []
         overlay_cmd = f"{editor_cmd} {shlex.quote(str(filepath))}"
         subprocess.run(
-            ["agtermctl", "session", "status", "blocked", "--blink", *target, *pane_args],
+            ["agtermctl", "session", "status", "blocked", "--blink", *target, *status_pane_args],
             stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
         )
         try:
             subprocess.run(
-                ["agtermctl", "session", "overlay", "open", overlay_cmd, *target, *pane_args, "--block"],
+                ["agtermctl", "session", "overlay", "open", overlay_cmd, *target, *overlay_pane_args, "--block"],
                 stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
             )
         finally:


### PR DESCRIPTION
Pass `--pane "$AGTERM_PANE"` to `agtermctl session overlay open` so plan-review, plan-annotate, and git-review overlays cover only the agent's pane, leaving the sibling pane live and usable.

Non-split sessions export `AGTERM_PANE=left`, which `--pane` accepts as a no-op, so no split-state detection is needed.

### Changed files

- `plugins/planning/scripts/launch-plan-review.sh` — build `AGTERM_PANE_ARG` from `$AGTERM_PANE`, pass to overlay open
- `plugins/planning/scripts/plan-annotate.py` — read `AGTERM_PANE`, pass `--pane` to overlay open
- `plugins/review/skills/git-review/scripts/git-review.py` — same pattern as plan-annotate

Fixes #40