### PR TITLE
fix(release-tools): correct the helper paths and make failures visible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ This repo ships independent Claude Code plugins. Version headings use values fro
 
 Entries are sorted by plugin version date, newest first.
 
+## release-tools v2.0.3 - 2026-08-19
+
+### Bug Fixes
+
+- the new-release skill now points at the real helper scripts. `ebd1cfb` renamed `skills/release` to `skills/new` but left the workflow steps calling `${CLAUDE_PLUGIN_ROOT}/skills/release/scripts/*.sh`, a path that does not exist in the plugin, so every step failed at runtime. The same rename left a stale `chmod` path in the manual install instructions
+- helper scripts are invoked with `bash` instead of `sh`, matching every other plugin. They carry a `#!/bin/bash` shebang and use bash-only syntax (`[[ ]]`, here-strings), which fails under a POSIX `sh` such as dash
+- `detect-platform.sh` now reports why it failed. `set -e` aborted on the failing `git remote get-url` before the check that prints `error: no origin remote configured` could run, so the caller got git's exit code and no explanation. Running outside a repository is reported separately
+- all three helpers write their errors to stderr. The skill captures stdout as the value (`platform=$(...)`), so an error message on stdout was swallowed into the variable and never shown
+
 ## planning v3.8.5 - 2026-08-17
 
 ### Bug Fixes

--- a/README.md
+++ b/README.md
@@ -79,8 +79,10 @@ Add the plan-annotate hook to `~/.claude/settings.json`:
 ```bash
 cp -r plugins/release-tools/skills/new ~/.claude/skills/
 cp -r plugins/release-tools/skills/last-tag ~/.claude/skills/
-chmod +x ~/.claude/skills/release/scripts/*.sh
+chmod +x ~/.claude/skills/new/scripts/*.sh
 ```
+
+Note: when installed manually, update the `${CLAUDE_PLUGIN_ROOT}` references inside `new/SKILL.md` to use the appropriate local paths instead.
 
 **thinking-tools** — skills:
 ```bash

--- a/plugins/release-tools/.claude-plugin/plugin.json
+++ b/plugins/release-tools/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "release-tools",
   "description": "Release workflow tools - auto-versioning, release notes, changelog updates",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "author": {
     "name": "Umputun"
   },

--- a/plugins/release-tools/skills/new/SKILL.md
+++ b/plugins/release-tools/skills/new/SKILL.md
@@ -45,7 +45,7 @@ Use AskUserQuestion tool to get release type:
 ### Step 2: Detect Platform
 
 ```bash
-platform=$(sh ${CLAUDE_PLUGIN_ROOT}/skills/release/scripts/detect-platform.sh)
+platform=$(bash ${CLAUDE_PLUGIN_ROOT}/skills/new/scripts/detect-platform.sh)
 ```
 
 ### Step 3: Validate Prerequisites
@@ -69,7 +69,7 @@ last_tag=$(git describe --tags --abbrev=0 --match "v*" 2>/dev/null || echo "none
 ### Step 5: Calculate New Version
 
 ```bash
-new_version=$(sh ${CLAUDE_PLUGIN_ROOT}/skills/release/scripts/calc-version.sh <release_type>)
+new_version=$(bash ${CLAUDE_PLUGIN_ROOT}/skills/new/scripts/calc-version.sh <release_type>)
 ```
 
 Verify tag doesn't already exist:
@@ -82,7 +82,7 @@ fi
 ### Step 6: Generate Release Notes
 
 ```bash
-notes=$(sh ${CLAUDE_PLUGIN_ROOT}/skills/release/scripts/get-notes.sh "$platform")
+notes=$(bash ${CLAUDE_PLUGIN_ROOT}/skills/new/scripts/get-notes.sh "$platform")
 ```
 
 Script logic:

--- a/plugins/release-tools/skills/new/scripts/calc-version.sh
+++ b/plugins/release-tools/skills/new/scripts/calc-version.sh
@@ -9,7 +9,7 @@ set -e
 release_type="$1"
 
 if [ -z "$release_type" ]; then
-    echo "error: release type required (major, minor, hotfix)"
+    echo "error: release type required (major, minor, hotfix)" >&2
     exit 1
 fi
 
@@ -25,7 +25,7 @@ if [ -z "$last_tag" ]; then
         major) echo "v1.0.0" ;;
         minor) echo "v0.1.0" ;;
         hotfix) echo "v0.0.1" ;;
-        *) echo "error: invalid type: $release_type"; exit 1 ;;
+        *) echo "error: invalid type: $release_type" >&2; exit 1 ;;
     esac
     exit 0
 fi
@@ -37,7 +37,7 @@ IFS='.' read -r major minor patch <<< "$base_version"
 
 # validate
 if ! [[ "$major" =~ ^[0-9]+$ ]] || ! [[ "$minor" =~ ^[0-9]+$ ]] || ! [[ "$patch" =~ ^[0-9]+$ ]]; then
-    echo "error: cannot parse version from $last_tag"
+    echo "error: cannot parse version from $last_tag" >&2
     exit 1
 fi
 
@@ -46,5 +46,5 @@ case "$release_type" in
     major) echo "v$((major + 1)).0.0" ;;
     minor) echo "v${major}.$((minor + 1)).0" ;;
     hotfix) echo "v${major}.${minor}.$((patch + 1))" ;;
-    *) echo "error: invalid type: $release_type"; exit 1 ;;
+    *) echo "error: invalid type: $release_type" >&2; exit 1 ;;
 esac

--- a/plugins/release-tools/skills/new/scripts/detect-platform.sh
+++ b/plugins/release-tools/skills/new/scripts/detect-platform.sh
@@ -1,13 +1,19 @@
 #!/bin/bash
 # detect GitHub vs GitLab vs Gitea from git remote
-# outputs: github, gitlab, gitea, or error message
+# outputs: github, gitlab or gitea on stdout, errors on stderr
 
 set -e
 
-remote_url=$(git remote get-url origin 2>/dev/null)
+if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+    echo "error: not a git repository" >&2
+    exit 1
+fi
+
+# || true keeps set -e from aborting when origin is missing, so the check below reports it
+remote_url=$(git remote get-url origin 2>/dev/null || true)
 
 if [ -z "$remote_url" ]; then
-    echo "error: no origin remote configured"
+    echo "error: no origin remote configured" >&2
     exit 1
 fi
 
@@ -20,6 +26,6 @@ elif echo "$remote_url" | grep -qiE "gitea\."; then
 elif command -v glab &>/dev/null && glab repo view &>/dev/null; then
     echo "gitlab"
 else
-    echo "error: unknown platform for $remote_url"
+    echo "error: unknown platform for $remote_url" >&2
     exit 1
 fi

--- a/plugins/release-tools/skills/new/scripts/get-notes.sh
+++ b/plugins/release-tools/skills/new/scripts/get-notes.sh
@@ -9,7 +9,7 @@ set -e
 platform="$1"
 
 if [ -z "$platform" ]; then
-    echo "error: platform required (github, gitlab, gitea)"
+    echo "error: platform required (github, gitlab, gitea)" >&2
     exit 1
 fi
 


### PR DESCRIPTION
Three fixes in release-tools, all found while adding test coverage for its helper scripts.

**The skill calls scripts that are not there.** `ebd1cfb` renamed `skills/release` to `skills/new`, but the workflow steps inside the skill still call `${CLAUDE_PLUGIN_ROOT}/skills/release/scripts/*.sh`. That path does not exist in the installed plugin, so all three steps that use a helper (detect platform, calculate version, generate release notes) fail at runtime with "No such file or directory", leaving the agent to improvise the release. The manual install instructions in README carried the same stale path in their `chmod` line.

**`sh` cannot run these scripts.** All three helpers carry a `#!/bin/bash` shebang and use `[[ ]]`, `=~` and here-strings, which a POSIX `sh` such as dash rejects. Every other plugin in the repo calls its helpers with `bash`; these now do too.

**`detect-platform.sh` could never report a missing origin.** `set -e` aborts on the failing `git remote get-url origin` before the `[ -z "$remote_url" ]` check runs, so the caller gets git's exit code 128 and no explanation instead of `error: no origin remote configured`. Verified in a fresh repo with no remote: it now prints the message and exits 1.

release-tools bumped to v2.0.3 with a changelog entry.
