### PR TITLE
feat(planning): add orca terminal backend to plan-review overlay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ This repo ships independent Claude Code plugins. Version headings use values fro
 
 Entries are sorted by plugin version date, newest first.
 
+## planning v3.9.0 - 2026-08-20
+
+### New Features
+
+- plan-review overlay: add an `orca` terminal backend to `launch-plan-review.sh`. Inside the Orca app (`TERM_PROGRAM=Orca`) the launcher had no matching branch, so the `ExitPlanMode` hook and `/planning:make` interactive review fell through to "no overlay terminal available" even with revdiff installed. The new branch opens revdiff in a new terminal tab via the orca CLI (`terminal create --command --focus`, pinned to the caller's worktree card through `ORCA_WORKTREE_ID`), blocks on a sentinel file until revdiff exits, then closes the tab with `terminal close --tab`. A sentinel is needed because `terminal create --command` runs inside an interactive shell that stays open after the command, so `terminal wait --for exit` never fires
+
 ## release-tools v2.0.3 - 2026-08-19
 
 ### Bug Fixes

--- a/README.md
+++ b/README.md
@@ -217,7 +217,7 @@ allow_remote_control yes
 listen_on unix:/tmp/kitty-$KITTY_PID
 ```
 
-*Note*: when `revdiff` is installed, the `ExitPlanMode` hook and `/planning:make` interactive review both route through `launch-plan-review.sh` instead, which supports a wider set of overlays: agterm, tmux, zellij, herdr, kitty, wezterm/kaku, cmux, ghostty, iTerm2, and emacs vterm. The 4-terminal list above applies only to the `$EDITOR` fallback when revdiff is not installed.
+*Note*: when `revdiff` is installed, the `ExitPlanMode` hook and `/planning:make` interactive review both route through `launch-plan-review.sh` instead, which supports a wider set of overlays: agterm, tmux, zellij, herdr, orca, kitty, wezterm/kaku, cmux, ghostty, iTerm2, and emacs vterm. The 4-terminal list above applies only to the `$EDITOR` fallback when revdiff is not installed.
 
 *Disabling review*: set `PLANNING_DISABLE_REVDIFF=1` to skip interactive plan review entirely on both routes (revdiff and the `$EDITOR` fallback). No overlay opens and the plan proceeds to the normal `ExitPlanMode` confirmation. This exists for remote clients (`claude /remote-control`): the overlay always opens on the host terminal, which a mobile or web client cannot see or interact with, so review would otherwise block the session. The variable is read when review fires, so export it in your shell before starting a session you may later drive remotely.
 

--- a/plugins/planning/.claude-plugin/plugin.json
+++ b/plugins/planning/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "planning",
   "description": "Structured implementation planning, interactive annotation review, and autonomous plan execution",
-  "version": "3.8.5",
+  "version": "3.9.0",
   "author": {
     "name": "Umputun"
   },

--- a/plugins/planning/scripts/launch-plan-review.sh
+++ b/plugins/planning/scripts/launch-plan-review.sh
@@ -2,7 +2,7 @@
 # launch revdiff for plan file review via terminal overlay.
 # usage: launch-plan-review.sh <plan-file-path>
 # output: annotations from revdiff stdout (empty if no annotations)
-# supports: agterm, tmux, zellij, herdr, kitty, wezterm/kaku, cmux, ghostty, iTerm2, emacs vterm
+# supports: agterm, tmux, zellij, herdr, orca, kitty, wezterm/kaku, cmux, ghostty, iTerm2, emacs vterm
 
 set -euo pipefail
 
@@ -185,6 +185,55 @@ LAUNCHER
         sleep 0.3
     done
     herdr tab close "$HERDR_TAB_ID" >/dev/null 2>&1 || true
+    rm -f "$SENTINEL" "$LAUNCH_SCRIPT"
+    cat "$OUTPUT_FILE"
+    exit 0
+fi
+
+# orca: open a new terminal tab via the orca CLI (the Orca app sets TERM_PROGRAM=Orca).
+# `terminal create --command` runs the command inside an interactive shell that stays
+# open afterwards, so `terminal wait --for exit` never fires — block on a sentinel file
+# instead and close the tab explicitly once revdiff exits
+if [ "${TERM_PROGRAM:-}" = "Orca" ] && command -v orca >/dev/null 2>&1; then
+    SENTINEL=$(mktemp "$TMPBASE/plan-review-done-XXXXXX")
+    rm -f "$SENTINEL"
+
+    LAUNCH_SCRIPT=$(mktemp "$TMPBASE/plan-review-launch-XXXXXX")
+    trap 'rm -f "$OUTPUT_FILE" "$SENTINEL" "$LAUNCH_SCRIPT"' EXIT
+    cat > "$LAUNCH_SCRIPT" <<LAUNCHER
+#!/bin/sh
+$REVDIFF_CMD; touch $(sq "$SENTINEL")
+LAUNCHER
+    chmod +x "$LAUNCH_SCRIPT"
+
+    # pin the tab to the caller's worktree card (ORCA_WORKTREE_ID is set in every Orca
+    # terminal) so it opens next to the session that asked for the review
+    ORCA_ARGS=(terminal create --title "$OVERLAY_TITLE" --command "sh $(sq "$LAUNCH_SCRIPT")" --focus --json)
+    [ -n "${ORCA_WORKTREE_ID:-}" ] && ORCA_ARGS+=(--worktree "id:$ORCA_WORKTREE_ID")
+    ORCA_NEW=$(orca "${ORCA_ARGS[@]}" 2>&1) || {
+        echo "error: orca terminal create failed: $ORCA_NEW" >&2
+        rm -f "$SENTINEL" "$LAUNCH_SCRIPT"
+        exit 1
+    }
+    # parse the handle: jq when available, grep fallback otherwise. || true keeps a
+    # parse miss from tripping set -e so the explicit check below can report it
+    ORCA_HANDLE=""
+    if command -v jq >/dev/null 2>&1; then
+        ORCA_HANDLE=$(printf '%s' "$ORCA_NEW" | jq -r '.result.terminal.handle // empty' 2>/dev/null || true)
+    fi
+    if [ -z "$ORCA_HANDLE" ]; then
+        ORCA_HANDLE=$(printf '%s' "$ORCA_NEW" | grep -o '"handle": *"[^"]*"' | head -1 | sed 's/.*"\([^"]*\)"$/\1/' || true)
+    fi
+    if [ -z "$ORCA_HANDLE" ]; then
+        echo "error: orca terminal create did not return a terminal handle: $ORCA_NEW" >&2
+        rm -f "$SENTINEL" "$LAUNCH_SCRIPT"
+        exit 1
+    fi
+
+    while [ ! -f "$SENTINEL" ]; do
+        sleep 0.3
+    done
+    orca terminal close --terminal "$ORCA_HANDLE" --tab >/dev/null 2>&1 || true
     rm -f "$SENTINEL" "$LAUNCH_SCRIPT"
     cat "$OUTPUT_FILE"
     exit 0
@@ -451,5 +500,5 @@ LAUNCHER
     exit 0
 fi
 
-echo "error: no overlay terminal available (requires agterm, tmux, zellij, herdr, kitty, wezterm, kaku, cmux, ghostty, iTerm2, or emacs vterm)" >&2
+echo "error: no overlay terminal available (requires agterm, tmux, zellij, herdr, orca, kitty, wezterm, kaku, cmux, ghostty, iTerm2, or emacs vterm)" >&2
 exit 1

--- a/plugins/planning/scripts/plan-review-hook.py
+++ b/plugins/planning/scripts/plan-review-hook.py
@@ -12,8 +12,8 @@ returns PreToolUse hook JSON response with permissionDecision:
 
 requirements:
   - revdiff (preferred) or $EDITOR (fallback)
-  - revdiff path: agterm, tmux, zellij, herdr, kitty, wezterm, kaku, cmux,
-    ghostty, iTerm2, or emacs vterm
+  - revdiff path: agterm, tmux, zellij, herdr, orca, kitty, wezterm, kaku,
+    cmux, ghostty, iTerm2, or emacs vterm
   - $EDITOR fallback (plan-annotate.py): agterm, tmux, kitty, or wezterm
 """
 


### PR DESCRIPTION
## what

adds an `orca` branch to `plugins/planning/scripts/launch-plan-review.sh` so the `ExitPlanMode` hook and `/planning:make` interactive review can open revdiff inside the [Orca](https://orca.app) app. Orca terminals set `TERM_PROGRAM=Orca` and ship an `orca` CLI, but matched none of the existing overlay branches, so with revdiff installed the launcher still ended in `error: no overlay terminal available`.

## how

mirrors the herdr branch:

- `orca terminal create --title "plan: <file>" --command "sh <launch-script>" --focus --json` opens a new terminal tab running revdiff (`--only=<plan> --output=<tmp> --wrap`), pinned to the caller's worktree card via `--worktree id:$ORCA_WORKTREE_ID` when that var is set
- the handle is parsed from `.result.terminal.handle` (jq, grep fallback)
- blocks on a sentinel file touched after revdiff exits, then `orca terminal close --terminal <handle> --tab`
- a sentinel is needed because `terminal create --command` runs the command inside an interactive shell that stays open afterwards, so `orca terminal wait --for exit` never fires (verified)

also: terminal lists in README / `plan-review-hook.py` docstring / launcher header+error updated, `planning` bumped 3.8.5 → 3.9.0, CHANGELOG entry added.

not included: the `$EDITOR` fallback in `plan-annotate.py` still has no Orca backend (only the revdiff path is covered here).

## tested

macOS, Orca 1.4.177, revdiff v1.12.0, Claude Code session running in an Orca terminal: `launch-plan-review.sh <plan>` opens a focused "plan: …" tab with revdiff, returns the annotations on `q`, closes the tab, leaves no temp files. `bash -n` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)