### PR TITLE
fix(planning): scope exec's stage-and-commit commit to its file list

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@
 
 # ralphex progress logs
 .ralphex/progress/
+
+# revmux round archives -- the profile is checked in, the runs are not
+.revmux/tasks/

--- a/.revmux/profile.md
+++ b/.revmux/profile.md
@@ -1,0 +1,54 @@
+# Project profile: cc-thingz
+
+## What it is
+
+A published marketplace of Claude Code plugins: hooks, skills and commands. There is no compiled code and
+no service. What ships is bash helper scripts, a few python scripts, and markdown prompt files that agents
+read and act on. Consumers install plugins by name from the marketplace, so anything under `plugins/` is a
+release artifact the moment it is tagged.
+
+## What a real failure looks like here
+
+The scripts run unattended, inside autonomous loops nobody is watching. The failures that matter are the
+ones that are silent:
+
+- a helper that corrupts a user's git state, commits the wrong files, or loses work
+- a prompt file that instructs an agent to do the wrong thing, or contradicts itself so the agent picks
+  either reading
+- a script that fails without saying why, or reports success after doing nothing
+- a path or name that does not resolve once the plugin is copied to its install cache
+
+A crash is not the worst case. A helper that exits 0 having done something wrong is, because the loop keeps
+going and the damage compounds across a run.
+
+## Blast radius
+
+Every user who installed the plugin, in their own repositories, on their own working trees. That is wider
+than a personal tool: the code runs on other people's git state. It is not production infrastructure and no
+customer data is at risk, but "the author can just fix it" does not apply.
+
+## Who runs and maintains it
+
+Solo maintainer (umputun), with a handful of repeat outside contributors. No on-call. CI runs shellcheck
+over every `.sh` in the repo, every `tests/test-*.sh` suite, and the python test flags.
+
+## Reporting bar
+
+Report anything that would make an unattended run do the wrong thing quietly, however narrow the trigger.
+Report a prompt or document that would mislead an agent executing it, at the severity the wrong action
+deserves, not as a documentation nit.
+
+Do not report: prose style in markdown, wording preferences, missing sections nobody asked for, or shell
+constructs that shellcheck already passes and that work on bash 3.2 and later.
+
+## Deliberate conventions, not defects
+
+- helper scripts use `${CLAUDE_PLUGIN_ROOT}` for path resolution; the plugin system copies files to a cache
+  location, so relative and absolute paths are wrong by design
+- each plugin carries its own `version` in `plugins/<name>/.claude-plugin/plugin.json` and is bumped
+  independently, with a matching `CHANGELOG.md` entry
+- scripts are `#!/bin/bash` and invoked with `bash`, never `sh`
+- markdown under `plugins/` is instructions for an agent, not documentation for a person. Judge it on
+  whether an agent following it literally does the right thing
+- subagents cannot spawn subagents, so any prompt needing parallel fan-out is executed by the main session
+  rather than handed to a spawned agent

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ This repo ships independent Claude Code plugins. Version headings use values fro
 
 Entries are sorted by plugin version date, newest first.
 
+## planning v3.9.1 - 2026-08-20
+
+### Bug Fixes
+
+- exec: `stage-and-commit.sh` no longer commits files outside the list it was given. The git arm ran `git add -- <files>` and then a bare `git commit`, which commits the whole index, so anything staged before the call was swept in — per-task commits stopped being a record of what the task changed, and a rejected commit left its own files staged for the next call to carry into an unrelated commit under the wrong message. The commit is now scoped to the listed paths, matching what the hg arm already did. A path-scoped commit runs hooks against a temporary index, so nothing a `pre-commit` hook stages reaches the real index — neither a reformatted copy of a listed file nor an unlisted one the hook adds itself, such as a regenerated lockfile. Every path the commit actually recorded is reconciled once it succeeds, so the index agrees with HEAD either way; reconciling only the listed paths would leave an unlisted one sitting in the index as a staged deletion of a file present in both HEAD and the working tree. Work that is staged but not committed is left staged rather than committed or discarded. File names are passed as `:(literal)` pathspecs so a name holding `*`, `?` or `[...]` matches itself instead of some other file, and the reconciliation anchors its paths with `:(top)` so a call made from a subdirectory still lands. An empty file argument is refused up front, since as a pathspec it would match everything under the current directory. Related to #46, reported by @paskal
+
 ## planning v3.9.0 - 2026-08-20
 
 ### New Features

--- a/docs/backlog/exec-accepts-a-task-that-never-committed.md
+++ b/docs/backlog/exec-accepts-a-task-that-never-committed.md
@@ -1,0 +1,27 @@
+---
+worth: later
+where: plugins/planning/skills/exec/SKILL.md
+added: 2026-08-20
+---
+# exec accepts a task as complete without checking that its commit succeeded
+
+A task subagent edits files, ticks its checkboxes in the plan, and calls `stage-and-commit.sh`. If that
+commit fails, the task's work stays in the working tree and its ticked checkboxes stay in the plan file.
+The orchestrator reads the checkboxes as the success signal and starts the next task, which edits the same
+plan file, lists it among its own changed files, and commits both tasks' checkbox changes under its own
+message.
+
+Scoping the commit to its file list (#46, PR #48) does not fix this. That fix stops a *disjoint* file being
+swept in, and it works: after a rejected commit the failed task's files stay staged and the next call
+commits only its own. But both tasks genuinely change the same plan file, so the second task's commit
+legitimately includes it, carrying the first task's ticks along. The overlap is in the working tree, not in
+the index, and nothing inside the commit helper can see it.
+
+The same applies to any source file two tasks both touch, which is why per-task commits cannot be trusted
+as a record of what one task changed whenever a commit has failed earlier in the run.
+
+The fix belongs in the orchestrator: either fail-stop the run when `stage-and-commit.sh` exits non-zero, or
+verify HEAD advanced before accepting a task as complete and moving on. Deferred because it changes the
+autonomous run's failure behaviour, which wants deciding on its own rather than inside a commit-helper fix.
+
+Surfaced by codex while vetting the #46 fix.

--- a/plugins/planning/.claude-plugin/plugin.json
+++ b/plugins/planning/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "planning",
   "description": "Structured implementation planning, interactive annotation review, and autonomous plan execution",
-  "version": "3.9.0",
+  "version": "3.9.1",
   "author": {
     "name": "Umputun"
   },

--- a/plugins/planning/skills/exec/scripts/stage-and-commit.sh
+++ b/plugins/planning/skills/exec/scripts/stage-and-commit.sh
@@ -10,19 +10,53 @@ if [ $# -lt 2 ]; then
     exit 1
 fi
 
+# an empty path must be rejected here: as a git pathspec it matches everything under
+# the current directory, so it would silently commit the whole tree instead of failing
+for arg in "${@:2}"; do
+    if [ -z "$arg" ]; then
+        echo "error: empty file argument" >&2
+        exit 1
+    fi
+done
+
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 vcs=$(bash "$SCRIPT_DIR/detect-vcs.sh")
 
 do_git() {
     local msg="$1"
     shift
-    git add -- "$@"
-    git commit -m "$msg"
+    # every name is passed as a :(literal) pathspec, so one holding '*', '?' or
+    # '[...]' matches itself rather than something else. the magic prefix is used
+    # rather than GIT_LITERAL_PATHSPECS because hooks inherit that variable and it
+    # would silently change how their own pathspecs resolve.
+    local path listed=()
+    for path in "$@"; do
+        listed+=(":(literal)$path")
+    done
+    git add -- "${listed[@]}"
+    git commit -m "$msg" -- "${listed[@]}"
+    # a path-scoped commit runs hooks against a temporary index, so nothing a
+    # pre-commit hook stages reaches the real index — neither a reformatted copy
+    # of a listed path nor an unlisted one the hook adds itself, such as a
+    # regenerated lockfile. reconcile every path the commit actually recorded,
+    # not just the listed ones: an unlisted path would otherwise sit in the index
+    # as a staged deletion of a file present in both HEAD and the worktree.
+    # anything staged but not committed is left alone.
+    # diff-tree reports paths from the repository root while a pathspec resolves
+    # against the current directory, so :(top) anchors them; without it the reset
+    # silently matches nothing whenever the caller sits in a subdirectory.
+    local committed=()
+    while IFS= read -r -d '' path; do
+        committed+=(":(top,literal)$path")
+    done < <(git diff-tree --no-commit-id --name-only -r --root -z HEAD)
+    if [ ${#committed[@]} -gt 0 ]; then
+        git reset -q -- "${committed[@]}"
+    fi
 }
 
 do_hg() {
     # -A marks untracked files as added and missing files as removed within the
-    # commit selection — parity with 'git add -- <files> && git commit'. Without
+    # commit selection — parity with the path-scoped git commit above. Without
     # -A, committing a new untracked file aborts with 'file not tracked'.
     local msg="$1"
     shift

--- a/tests/test-exec-vcs-dispatch.sh
+++ b/tests/test-exec-vcs-dispatch.sh
@@ -429,6 +429,235 @@ assert_output "git/new: commit subject matches" "add newfile" "$subject"
 files="$(git -C "$GIT_SC_NEW" show --name-only --pretty=format: HEAD | sed '/^$/d')"
 assert_output "git/new: commit contains newfile.txt" "newfile.txt" "$files"
 
+# test 11b: anything staged before the call must stay out of the commit and stay staged.
+# regression for the git arm committing the whole index instead of the listed files
+echo ""
+echo "test 11b: git repo, unrelated staged file -> not committed, still staged"
+GIT_SC_SCOPE="$(mk_tmp)"
+make_git_repo "$GIT_SC_SCOPE" main
+(
+    cd "$GIT_SC_SCOPE"
+    echo "a" >a.txt
+    echo "b" >b.txt
+    git add a.txt b.txt
+    git commit -q -m "seed both"
+    echo "a2" >a.txt
+    echo "b2" >b.txt
+    git add b.txt
+)
+rc=0
+(cd "$GIT_SC_SCOPE" && bash "$STAGE_AND_COMMIT" "commit a only" a.txt >/dev/null 2>&1) || rc=$?
+assert_output "git/scope: exit code 0" "0" "$rc"
+files="$(git -C "$GIT_SC_SCOPE" show --name-only --pretty=format: HEAD | sed '/^$/d')"
+assert_output "git/scope: commit contains only a.txt" "a.txt" "$files"
+staged="$(git -C "$GIT_SC_SCOPE" diff --cached --name-only)"
+assert_output "git/scope: b.txt is still staged afterwards" "b.txt" "$staged"
+
+# test 11c: a pre-commit hook that reformats and re-adds files writes into the temporary
+# index git builds for a path-scoped commit. without the trailing path-scoped reset the real
+# index keeps the pre-hook content and every commit leaves a phantom staged change behind
+echo ""
+echo "test 11c: git repo, restaging pre-commit hook -> no phantom staged change"
+GIT_SC_HOOK="$(mk_tmp)"
+HOOK_DIR="$(mk_tmp)"
+cat >"$HOOK_DIR/pre-commit" <<'HOOK'
+#!/bin/sh
+for f in $(git diff --cached --name-only --diff-filter=ACM -- "*.txt"); do
+    tr "a-z" "A-Z" <"$f" >"$f.tmp" && mv "$f.tmp" "$f"
+    git add -- "$f"
+done
+exit 0
+HOOK
+chmod +x "$HOOK_DIR/pre-commit"
+make_git_repo "$GIT_SC_HOOK" main
+(
+    cd "$GIT_SC_HOOK"
+    echo "seed" >seed.txt
+    git add seed.txt
+    git commit -q -m "seed"
+    git config core.hooksPath "$HOOK_DIR"
+    echo "src" >src.txt
+    echo "other" >other.txt
+    git add other.txt
+)
+rc=0
+(cd "$GIT_SC_HOOK" && bash "$STAGE_AND_COMMIT" "add src" src.txt >/dev/null 2>&1) || rc=$?
+assert_output "git/hook: exit code 0" "0" "$rc"
+assert_output "git/hook: HEAD holds the hook's formatting" "SRC" "$(git -C "$GIT_SC_HOOK" show HEAD:src.txt)"
+assert_output "git/hook: index agrees with HEAD" "SRC" "$(git -C "$GIT_SC_HOOK" show ":src.txt")"
+assert_output "git/hook: worktree agrees with HEAD" "SRC" "$(cat "$GIT_SC_HOOK/src.txt")"
+assert_output "git/hook: no phantom diff for the listed path" "" "$(git -C "$GIT_SC_HOOK" diff --name-only -- src.txt)"
+assert_output "git/hook: unrelated staged file survives" "other.txt" "$(git -C "$GIT_SC_HOOK" diff --cached --name-only)"
+assert_output "git/hook: hook did not reach the unrelated file" "other" "$(git -C "$GIT_SC_HOOK" show ":other.txt")"
+
+# test 11f: a hook may stage a path the caller never listed, such as a regenerated lockfile.
+# that path is committed from the temporary index, so reconciling only the listed paths would
+# leave it in the real index as a staged deletion of a file present in HEAD and the worktree
+echo ""
+echo "test 11f: git repo, hook stages an unlisted path -> index still agrees with HEAD"
+GIT_SC_OUTSIDE="$(mk_tmp)"
+OUTSIDE_HOOK_DIR="$(mk_tmp)"
+cat >"$OUTSIDE_HOOK_DIR/pre-commit" <<'HOOK'
+#!/bin/sh
+echo "generated" >gen.lock
+git add -- gen.lock
+exit 0
+HOOK
+chmod +x "$OUTSIDE_HOOK_DIR/pre-commit"
+make_git_repo "$GIT_SC_OUTSIDE" main
+(
+    cd "$GIT_SC_OUTSIDE"
+    echo "seed" >seed.txt
+    git add seed.txt
+    git commit -q -m "seed"
+    git config core.hooksPath "$OUTSIDE_HOOK_DIR"
+    echo "src" >src.txt
+)
+rc=0
+(cd "$GIT_SC_OUTSIDE" && bash "$STAGE_AND_COMMIT" "add src" src.txt >/dev/null 2>&1) || rc=$?
+assert_output "git/outside: exit code 0" "0" "$rc"
+files="$(git -C "$GIT_SC_OUTSIDE" show --name-only --pretty=format: HEAD | sed '/^$/d' | sort | tr '\n' ' ')"
+assert_output "git/outside: commit carries the hook's unlisted path" "gen.lock src.txt " "$files"
+assert_output "git/outside: no staged deletion left behind" "" "$(git -C "$GIT_SC_OUTSIDE" status --porcelain)"
+
+# test 11g: diff-tree reports paths from the repository root while reset resolves them against
+# the current directory, so a call made from a subdirectory must still reconcile the index
+echo ""
+echo "test 11g: git repo, called from a subdirectory -> index still agrees with HEAD"
+GIT_SC_SUBDIR="$(mk_tmp)"
+SUBDIR_HOOK_DIR="$(mk_tmp)"
+cat >"$SUBDIR_HOOK_DIR/pre-commit" <<'HOOK'
+#!/bin/sh
+root=$(git rev-parse --show-toplevel)
+echo "generated" >"$root/gen.lock"
+git add -- "$root/gen.lock"
+exit 0
+HOOK
+chmod +x "$SUBDIR_HOOK_DIR/pre-commit"
+make_git_repo "$GIT_SC_SUBDIR" main
+(
+    cd "$GIT_SC_SUBDIR"
+    mkdir -p services/foo
+    echo "seed" >seed.txt
+    git add seed.txt
+    git commit -q -m "seed"
+    git config core.hooksPath "$SUBDIR_HOOK_DIR"
+    echo "src" >services/foo/src.txt
+)
+rc=0
+(cd "$GIT_SC_SUBDIR/services/foo" && bash "$STAGE_AND_COMMIT" "feat: x" src.txt >/dev/null 2>&1) || rc=$?
+assert_output "git/subdir: exit code 0" "0" "$rc"
+files="$(git -C "$GIT_SC_SUBDIR" show --name-only --pretty=format: HEAD | sed '/^$/d' | sort | tr '\n' ' ')"
+assert_output "git/subdir: commit carries both paths" "gen.lock services/foo/src.txt " "$files"
+assert_output "git/subdir: no staged deletion left behind" "" "$(git -C "$GIT_SC_SUBDIR" status --porcelain)"
+
+# test 11h: file names are literal paths, not globs. without GIT_LITERAL_PATHSPECS a name
+# holding glob characters matches a different file, so the named one keeps a stale index entry
+# while unrelated staged work is silently unstaged
+echo ""
+echo "test 11h: git repo, glob characters in a filename -> matched literally"
+GIT_SC_GLOB="$(mk_tmp)"
+make_git_repo "$GIT_SC_GLOB" main
+(
+    cd "$GIT_SC_GLOB"
+    mkdir -p docs
+    echo "bracket" >'docs/task[1].md'
+    echo "plain" >docs/task1.md
+    git add docs
+    git commit -q -m "seed docs"
+    echo "bracket2" >'docs/task[1].md'
+    echo "plain2" >docs/task1.md
+    git add docs/task1.md
+)
+rc=0
+(cd "$GIT_SC_GLOB" && bash "$STAGE_AND_COMMIT" "update bracket" 'docs/task[1].md' >/dev/null 2>&1) || rc=$?
+assert_output "git/glob: exit code 0" "0" "$rc"
+files="$(git -C "$GIT_SC_GLOB" show --name-only --pretty=format: HEAD | sed '/^$/d')"
+assert_output "git/glob: commit contains only the named file" 'docs/task[1].md' "$files"
+assert_output "git/glob: unrelated staged file untouched" "docs/task1.md" "$(git -C "$GIT_SC_GLOB" diff --cached --name-only)"
+
+# test 11i: an empty path is a match-all git pathspec, so it has to be rejected before it
+# reaches git or the call silently commits the whole tree instead of failing
+echo ""
+echo "test 11i: git repo, empty file argument -> refused, nothing committed"
+GIT_SC_EMPTY="$(mk_tmp)"
+make_git_repo "$GIT_SC_EMPTY" main
+(
+    cd "$GIT_SC_EMPTY"
+    echo "a" >a.txt
+    echo "b" >b.txt
+    git add a.txt b.txt
+    git commit -q -m "seed"
+    echo "a2" >a.txt
+    echo "b2" >b.txt
+)
+before="$(git -C "$GIT_SC_EMPTY" rev-parse HEAD)"
+rc=0
+err="$( (cd "$GIT_SC_EMPTY" && bash "$STAGE_AND_COMMIT" "msg" "" 2>&1 >/dev/null) )" || rc=$?
+assert_exit_nonzero "git/empty: exits non-zero" "$rc"
+assert_contains "git/empty: names the empty argument" "$err" "empty file argument"
+assert_output "git/empty: no commit made" "$before" "$(git -C "$GIT_SC_EMPTY" rev-parse HEAD)"
+
+# test 11d: a rejected commit leaves its files staged. the next call must commit only its own
+# files rather than sweeping up the failed call's leftovers under the wrong message
+echo ""
+echo "test 11d: git repo, failed commit then disjoint call -> no carryover"
+GIT_SC_FAIL="$(mk_tmp)"
+FAIL_HOOK_DIR="$(mk_tmp)"
+cat >"$FAIL_HOOK_DIR/pre-commit" <<'HOOK'
+#!/bin/sh
+marker="$(git rev-parse --absolute-git-dir)/reject-once"
+if [ ! -f "$marker" ]; then
+    touch "$marker"
+    exit 1
+fi
+exit 0
+HOOK
+chmod +x "$FAIL_HOOK_DIR/pre-commit"
+make_git_repo "$GIT_SC_FAIL" main
+(
+    cd "$GIT_SC_FAIL"
+    echo "seed" >seed.txt
+    git add seed.txt
+    git commit -q -m "seed"
+    git config core.hooksPath "$FAIL_HOOK_DIR"
+    echo "one" >task1.txt
+)
+rc=0
+(cd "$GIT_SC_FAIL" && bash "$STAGE_AND_COMMIT" "feat: task 1" task1.txt >/dev/null 2>&1) || rc=$?
+assert_exit_nonzero "git/carryover: rejected commit exits non-zero" "$rc"
+assert_output "git/carryover: rejected files stay staged" "task1.txt" "$(git -C "$GIT_SC_FAIL" diff --cached --name-only)"
+(cd "$GIT_SC_FAIL" && echo "two" >task2.txt)
+rc=0
+(cd "$GIT_SC_FAIL" && bash "$STAGE_AND_COMMIT" "feat: task 2" task2.txt >/dev/null 2>&1) || rc=$?
+assert_output "git/carryover: second call exit code 0" "0" "$rc"
+files="$(git -C "$GIT_SC_FAIL" show --name-only --pretty=format: HEAD | sed '/^$/d')"
+assert_output "git/carryover: second commit contains only task2.txt" "task2.txt" "$files"
+assert_output "git/carryover: task1.txt still staged for the retry" "task1.txt" "$(git -C "$GIT_SC_FAIL" diff --cached --name-only)"
+
+# test 11e: a path-scoped commit must still record a removal, with the reset that follows
+# leaving no residue for the deleted path
+echo ""
+echo "test 11e: git repo, deleted tracked file -> removal recorded, scope held"
+GIT_SC_DEL="$(mk_tmp)"
+make_git_repo "$GIT_SC_DEL" main
+(
+    cd "$GIT_SC_DEL"
+    echo "seed" >seed.txt
+    echo "gone" >gone.txt
+    echo "other" >other.txt
+    git add seed.txt gone.txt
+    git commit -q -m "seed"
+    rm -f gone.txt
+    git add other.txt
+)
+rc=0
+(cd "$GIT_SC_DEL" && bash "$STAGE_AND_COMMIT" "remove gone" gone.txt >/dev/null 2>&1) || rc=$?
+assert_output "git/deleted: exit code 0" "0" "$rc"
+status="$(git -C "$GIT_SC_DEL" show --name-status --pretty=format: HEAD | sed '/^$/d')"
+assert_output "git/deleted: removal recorded" "D	gone.txt" "$status"
+assert_output "git/deleted: other.txt still staged" "other.txt" "$(git -C "$GIT_SC_DEL" diff --cached --name-only)"
+
 if [ "$HG_AVAILABLE" -eq 1 ]; then
     # test 12: hg repo, modified tracked file -> committed via hg commit -A
     echo ""
@@ -470,6 +699,28 @@ if [ "$HG_AVAILABLE" -eq 1 ]; then
     assert_output "hg/new: commit subject matches" "add newfile" "$subject"
     files="$(cd "$HG_SC_NEW" && hg log -l 1 -T '{files}')"
     assert_output "hg/new: commit contains newfile.txt" "newfile.txt" "$files"
+
+    # test 13b: hg counterpart of 11b. hg has no index, so the unrelated change is a modified
+    # tracked file rather than a staged one; it must stay out of the commit and stay pending
+    echo ""
+    echo "test 13b: hg repo, unrelated modified file -> not committed, still pending"
+    HG_SC_SCOPE="$(mk_tmp)"
+    make_hg_repo "$HG_SC_SCOPE"
+    (
+        cd "$HG_SC_SCOPE"
+        echo "a" >a.txt
+        echo "b" >b.txt
+        hg add a.txt b.txt >/dev/null
+        hg commit -m "seed both" >/dev/null
+        echo "a2" >a.txt
+        echo "b2" >b.txt
+    )
+    rc=0
+    (cd "$HG_SC_SCOPE" && bash "$STAGE_AND_COMMIT" "commit a only" a.txt >/dev/null 2>&1) || rc=$?
+    assert_output "hg/scope: exit code 0" "0" "$rc"
+    files="$(cd "$HG_SC_SCOPE" && hg log -l 1 -T '{files}')"
+    assert_output "hg/scope: commit contains only a.txt" "a.txt" "$files"
+    assert_output "hg/scope: b.txt is still pending afterwards" "M b.txt" "$(cd "$HG_SC_SCOPE" && hg status)"
 
     # test 14: hg repo with deleted tracked file -> hg commit -A records the removal
     echo ""


### PR DESCRIPTION
`stage-and-commit.sh` takes an explicit file list, but the git arm ran `git add -- "$@"` and then a bare `git commit`, which commits the whole index. Anything staged before the call was swept in. The hg arm was already path-scoped, so the two backends disagreed about what a commit contains. Fixes #46, reported by @paskal.

Two ways this bites the exec loop. Per-task and fixer commits stop being a record of what that task changed, and the plan-move commit can carry unrelated work. A rejected commit also leaves its own files staged, so the next call in the same run committed them under the wrong message, which needs nothing outside the plugin to trigger:

```
task1 commit rejected  -> task1.txt stays staged
task2 commit succeeds  -> commit "feat: task 2" contains task1.txt + task2.txt
```

**What changed**

The commit is now scoped to the listed paths, matching hg. That alone is not enough: a path-scoped commit runs hooks against a temporary index, so nothing a `pre-commit` hook stages reaches the real index. Not a reformatted copy of a listed file, and not an unlisted one the hook adds itself such as a regenerated lockfile. Left alone that leaves a phantom staged change after every commit, a bogus `git diff` for the external reviewer, and a failing finalize rebase.

So every path the commit actually recorded is reconciled once it succeeds, not just the listed ones. Reconciling only the listed paths would leave an unlisted one sitting in the index as a staged deletion of a file present in both HEAD and the working tree. Work that is staged but not committed is left staged, neither committed nor discarded.

Three smaller points, each with its own test:

- names are passed as `:(literal)` pathspecs, so one holding `*`, `?` or `[...]` matches itself instead of another file. The magic prefix is used rather than `GIT_LITERAL_PATHSPECS` because hooks inherit that variable and it would change how their own pathspecs resolve
- the reconciliation anchors its paths with `:(top)`. `git diff-tree` reports repository-root-relative paths while a pathspec resolves against the current directory, so without it a call from a subdirectory silently matched nothing
- an empty file argument is refused up front. As a pathspec it matches everything under the current directory, so `stage-and-commit.sh "msg" ""` would commit the whole tree and exit 0

Operation-state handling is out of scope rather than impossible. Mid-merge and mid-cherry-pick the scoped commit refuses, as hg already does. Mid-rebase and mid-revert it succeeds but splits the operation, and no bundled call site commits mid-operation.

**Tests**

`tests/test-exec-vcs-dispatch.sh` had no case starting from a dirty index. Added: unrelated staged work, a restaging formatter hook, a hook staging an unlisted path, a call from a subdirectory, glob characters in a filename, an empty argument, a rejected commit followed by a disjoint call, deletions, and the hg counterpart. All confirmed failing against the previous script.

planning bumped to 3.9.1 with a changelog entry.
