### PR TITLE
ci: reject unterminated frontmatter and fix the macOS temp-dir guard

### DIFF
--- a/.github/scripts/check-frontmatter.py
+++ b/.github/scripts/check-frontmatter.py
@@ -6,7 +6,10 @@ the block must be terminated by a closing '---' and must parse as YAML. an
 unterminated block fails - the loader never sees the metadata, so a truncated
 skill or agent header would otherwise ship unnoticed.
 
-files that do not open with '---' have no frontmatter and are skipped.
+files that do not open with '---' have no frontmatter and are skipped. a BOM, CRLF
+line endings and trailing blanks on a delimiter line are normalised away first, so a
+file saved by a Windows or whitespace-happy editor is checked rather than silently
+skipped. files are decoded as UTF-8 regardless of the ambient locale.
 
 usage:
     check-frontmatter.py [root]     validate tree (default: current directory)
@@ -14,6 +17,7 @@ usage:
 """
 
 import os
+import re
 import sys
 from pathlib import Path
 
@@ -22,25 +26,42 @@ import yaml
 
 def check_content(content: str) -> str | None:
     """validate frontmatter of a markdown document. returns error text or None when valid."""
+    # normalise so a BOM or CRLF endings do not make a real '---' line unrecognisable,
+    # which would skip the file as "no frontmatter" and hide broken metadata. the
+    # trailing newline lets a closing '---' on the last line be found by the same
+    # search as every other one, instead of needing its own offset arithmetic
+    content = content.lstrip("\ufeff").replace("\r\n", "\n")
+    if not content.endswith("\n"):
+        content += "\n"
+
+    # trailing blanks on a delimiter line are the same class of near-miss as a BOM or
+    # CRLF: '--- \n' opens frontmatter for every YAML reader, so leaving it unmatched
+    # would skip the file silently, and matching only the opener would then call a
+    # valid block unterminated
+    content = re.sub(r"^---[ \t]+$", "---", content, flags=re.MULTILINE)
+
     if not content.startswith("---\n"):
         return None
 
     # closing delimiter starts at index 3 so an empty block ('---\n---\n') is accepted
     end = content.find("\n---\n", 3)
     if end == -1:
-        if content.endswith("\n---"):
-            # closing delimiter is the last line, with no trailing newline
-            end = len(content) - 4
-        else:
-            return (
-                "unterminated frontmatter: no closing '---'. "
-                "if the document deliberately opens with a horizontal rule, write it as '***'"
-            )
+        return (
+            "unterminated frontmatter: no closing '---'. "
+            "if the document deliberately opens with a horizontal rule, write it as '***'"
+        )
 
     try:
-        yaml.safe_load(content[4:end])
+        parsed = yaml.safe_load(content[4:end])
     except yaml.YAMLError as e:
         return str(e)
+
+    # safe_load happily returns a scalar or a list for text that is valid YAML but not a
+    # header: 'name thing' with the colon dropped parses as the string 'name thing' and
+    # would pass, while the loader gets no name/description -- exactly the shipped-broken-
+    # metadata case this gate exists to catch. None stays valid: that is an empty block
+    if parsed is not None and not isinstance(parsed, dict):
+        return f"frontmatter is not a YAML mapping (parsed as {type(parsed).__name__})"
     return None
 
 
@@ -53,7 +74,16 @@ def check_tree(root: str = ".") -> list[tuple[str, str]]:
             if not name.endswith(".md"):
                 continue
             path = os.path.join(dirpath, name)
-            error = check_content(Path(path).read_text())
+            # a dangling symlink or a non-UTF-8 file must be reported as that file's
+            # failure, not raise out of the walk and leave every later file unchecked
+            try:
+                # explicit utf-8: read_text() would otherwise decode with the ambient
+                # locale, so on a non-UTF-8 host every file carrying an em-dash fails
+                content = Path(path).read_text(encoding="utf-8")
+            except (OSError, UnicodeDecodeError) as e:
+                failures.append((path, f"unreadable: {e}"))
+                continue
+            error = check_content(content)
             if error:
                 failures.append((path, error))
     return failures
@@ -64,7 +94,14 @@ def main(argv: list[str]) -> int:
         run_tests()
         return 0
 
-    failures = check_tree(argv[0] if argv else ".")
+    root = argv[0] if argv else "."
+    # os.walk on a missing path yields nothing, so without this the check reports
+    # success having validated zero files -- a typo would silently disable the gate
+    if not os.path.isdir(root):
+        print(f"error: not a directory: {root}", file=sys.stderr)
+        return 1
+
+    failures = check_tree(root)
     for path, error in failures:
         print(f"FAIL: {path}")
         print(f"  {error}")
@@ -76,6 +113,8 @@ def main(argv: list[str]) -> int:
 
 def run_tests() -> None:
     """run embedded unit tests."""
+    import contextlib
+    import io
     import tempfile
     import unittest
 
@@ -108,8 +147,39 @@ def run_tests() -> None:
             self.assertIsNotNone(error)
             self.assertNotIn("unterminated", error)
 
+        def test_non_mapping_frontmatter_is_rejected(self) -> None:
+            # a dropped colon still parses as valid YAML -- as a bare string, which leaves
+            # the loader with no name/description
+            error = check_content("---\nname thing\n---\n")
+            self.assertIsNotNone(error)
+            self.assertIn("not a YAML mapping", error)
+            self.assertIsNotNone(check_content("---\n- a\n- b\n---\n"))
+            self.assertIsNotNone(check_content("---\n42\n---\n"))
+
         def test_tab_indent_is_invalid_yaml(self) -> None:
             self.assertIsNotNone(check_content("---\nname: thing\n\tbad: indent\n---\n"))
+
+        def test_crlf_frontmatter_is_checked(self) -> None:
+            # a file saved with CRLF must not read as "no frontmatter" and slip through
+            self.assertIsNone(check_content("---\r\nname: thing\r\n---\r\n\r\nbody\r\n"))
+            error = check_content("---\r\nname: thing\r\n\r\nbody\r\n")
+            self.assertIsNotNone(error)
+            self.assertIn("unterminated", error)
+
+        def test_bom_frontmatter_is_checked(self) -> None:
+            self.assertIsNone(check_content("\ufeff---\nname: thing\n---\n"))
+            error = check_content("\ufeff---\nname: thing\n\nbody\n")
+            self.assertIsNotNone(error)
+            self.assertIn("unterminated", error)
+
+        def test_delimiter_with_trailing_blanks_is_checked(self) -> None:
+            # a trailing space must not make the block invisible, nor make a
+            # terminated block look unterminated
+            self.assertIsNone(check_content("--- \nname: thing\n---\t\n\nbody\n"))
+            error = check_content("--- \nname: thing\n\nbody\n")
+            self.assertIsNotNone(error)
+            self.assertIn("unterminated", error)
+            self.assertIsNotNone(check_content("--- \nname: [unclosed\n--- \n"))
 
     class TestCheckTree(unittest.TestCase):
         def write(self, root: str, rel: str, content: str) -> None:
@@ -142,9 +212,41 @@ def run_tests() -> None:
                 self.write(root, "broken.txt", "---\nname: broken\n\nbody\n")
                 self.assertEqual(check_tree(root), [])
 
+        def test_unreadable_file_does_not_stop_the_walk(self) -> None:
+            # sorted before 'zbroken.md', so a raise here would hide the real failure
+            with tempfile.TemporaryDirectory() as root:
+                (Path(root) / "adangling.md").symlink_to(Path(root) / "gone")
+                (Path(root) / "bbinary.md").write_bytes(b"\xff\xfe---\nname: x\n")
+                self.write(root, "zbroken.md", "---\nname: broken\n\nbody\n")
+                failures = dict(check_tree(root))
+                names = sorted(Path(p).name for p in failures)
+                self.assertEqual(names, ["adangling.md", "bbinary.md", "zbroken.md"])
+                self.assertIn("unreadable", failures[str(Path(root) / "adangling.md")])
+
+    class TestMain(unittest.TestCase):
+        def run_main(self, argv: list[str]) -> int:
+            # main() prints its report; swallow it so the test log stays readable
+            with contextlib.redirect_stdout(io.StringIO()), contextlib.redirect_stderr(io.StringIO()):
+                return main(argv)
+
+        def test_clean_tree_returns_zero(self) -> None:
+            with tempfile.TemporaryDirectory() as root:
+                (Path(root) / "good.md").write_text("---\nname: good\n---\n")
+                self.assertEqual(self.run_main([root]), 0)
+
+        def test_broken_tree_returns_one(self) -> None:
+            with tempfile.TemporaryDirectory() as root:
+                (Path(root) / "broken.md").write_text("---\nname: broken\n\nbody\n")
+                self.assertEqual(self.run_main([root]), 1)
+
+        def test_missing_root_returns_one(self) -> None:
+            # a typo'd path must fail loudly rather than validate zero files and pass
+            with tempfile.TemporaryDirectory() as root:
+                self.assertEqual(self.run_main([str(Path(root) / "nope")]), 1)
+
     loader = unittest.TestLoader()
     suite = unittest.TestSuite()
-    for tc in [TestCheckContent, TestCheckTree]:
+    for tc in [TestCheckContent, TestCheckTree, TestMain]:
         suite.addTests(loader.loadTestsFromTestCase(tc))
     runner = unittest.TextTestRunner(verbosity=2)
     result = runner.run(suite)

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,7 @@
 
 # revmux round archives -- the profile is checked in, the runs are not
 .revmux/tasks/
+
+# python bytecode
+__pycache__/
+*.pyc

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,6 +20,7 @@ Things to make Claude Code even better — hooks, skills, and commands, organize
 - Manual install instructions are kept in README.md as a fallback for users who prefer direct setup.
 - **Versioning** — each plugin has its own `version` in `plugins/<name>/.claude-plugin/plugin.json`. Bump independently per plugin. Use semver: patch for bug fixes, minor for new components, major for breaking changes. **Bump triggers on any change to bundled plugin content** — prompts, agents, references (e.g., `usage.md`), scripts, commands, hooks — not just `.claude-plugin/` files. Anything shipped to consumers via the plugin is a release artifact.
 - **Changelog**: when bumping a plugin version, update `CHANGELOG.md` in the same change. Version headings use the plugin name and plugin version (e.g., `## planning v3.7.1 - YYYY-MM-DD`), not tags. Keep entries grouped like the changelog style: New Features, Improvements, Bug Fixes, Other.
+- **Markdown frontmatter** — a `.md` file whose first line is `---` is treated as YAML frontmatter and must close the block with another `---`; CI fails on an unterminated one (`.github/scripts/check-frontmatter.py`). A document that deliberately opens with a horizontal rule has to write it as `***`.
 - **Cross-references** — when skills reference other skills within the same plugin, use the plugin name prefix (e.g., `/review:writing-style`). When referencing skills in other plugins, use that plugin's name (e.g., `/planning:make`).
 
 ## Structure

--- a/tests/test-brainstorm-resolve-rules.sh
+++ b/tests/test-brainstorm-resolve-rules.sh
@@ -16,12 +16,15 @@ failed=0
 WORK_DIR="$(mktemp -d)"
 USER_DIR="$(mktemp -d)"
 
-# safety: verify dirs are under /tmp or $TMPDIR before allowing any rm operations
+# safety: verify dirs live under the directory mktemp actually uses before any rm.
+# the base comes from mktemp itself, not $TMPDIR -- BSD mktemp on macOS ignores
+# TMPDIR for the default template and always uses _CS_DARWIN_USER_TEMP_DIR
+# (/var/folders/.../T), so comparing against $TMPDIR aborts the suite on every
+# macOS host. both dirs below come from a bare `mktemp -d`, so they share this base
+TMP_BASE="$(dirname "$(mktemp -u)")"
 assert_temp_dir() {
     local dir="$1"
-    local tmpbase="${TMPDIR:-/tmp}"
-    tmpbase="${tmpbase%/}"
-    case "$dir" in "$tmpbase"/*) ;; *) echo "FATAL: $dir is not under $tmpbase, refusing to proceed" >&2; exit 1;; esac
+    case "$dir" in "$TMP_BASE"/?*) ;; *) echo "FATAL: $dir is not under $TMP_BASE, refusing to proceed" >&2; exit 1;; esac
 }
 assert_temp_dir "$WORK_DIR"
 assert_temp_dir "$USER_DIR"

--- a/tests/test-planning-resolve-rules.sh
+++ b/tests/test-planning-resolve-rules.sh
@@ -16,12 +16,15 @@ failed=0
 WORK_DIR="$(mktemp -d)"
 USER_DIR="$(mktemp -d)"
 
-# safety: verify dirs are under /tmp or $TMPDIR before allowing any rm operations
+# safety: verify dirs live under the directory mktemp actually uses before any rm.
+# the base comes from mktemp itself, not $TMPDIR -- BSD mktemp on macOS ignores
+# TMPDIR for the default template and always uses _CS_DARWIN_USER_TEMP_DIR
+# (/var/folders/.../T), so comparing against $TMPDIR aborts the suite on every
+# macOS host. both dirs below come from a bare `mktemp -d`, so they share this base
+TMP_BASE="$(dirname "$(mktemp -u)")"
 assert_temp_dir() {
     local dir="$1"
-    local tmpbase="${TMPDIR:-/tmp}"
-    tmpbase="${tmpbase%/}"
-    case "$dir" in "$tmpbase"/*) ;; *) echo "FATAL: $dir is not under $tmpbase, refusing to proceed" >&2; exit 1;; esac
+    case "$dir" in "$TMP_BASE"/?*) ;; *) echo "FATAL: $dir is not under $TMP_BASE, refusing to proceed" >&2; exit 1;; esac
 }
 assert_temp_dir "$WORK_DIR"
 assert_temp_dir "$USER_DIR"


### PR DESCRIPTION
Split out of #43, which had accumulated three unrelated plugin releases under a title about issue #42. This half touches no plugin and needs no version bump, so it can merge independently.

Unchanged from what was already reviewed there across four rounds — no new work in this PR.

## check-frontmatter.py

The gate skipped any file it could not recognise as opening with frontmatter, and three near-misses all landed in that bucket: a leading BOM, CRLF line endings, and trailing blanks on a delimiter line. Every YAML reader treats those as opening a block, so a file with broken metadata passed silently. Content is normalised first — BOM stripped, CRLF folded, trailing blanks on a `---` line trimmed, decoded as UTF-8 regardless of ambient locale.

`safe_load` also accepted anything that was valid YAML rather than a header. A `name thing` line with the colon dropped parses as a plain string and passed, while the loader saw no name and no description — exactly the shipped-broken-metadata case the gate exists to catch. A block parsing as anything other than a mapping is now an error; an empty block stays valid.

The special case for a closing `---` on the last line without a trailing newline is gone, replaced by appending the newline up front so one search handles every position.

## macOS temp-dir guard

`test-brainstorm-resolve-rules.sh` and `test-planning-resolve-rules.sh` compared their scratch dirs against `$TMPDIR` before allowing any `rm`. BSD `mktemp` ignores `TMPDIR` for the default template and always uses `_CS_DARWIN_USER_TEMP_DIR`, so the guard aborted both suites on every macOS host. The base now comes from `mktemp` itself.

Reproduced on master before the fix:

```
test-brainstorm-resolve-rules.sh  FATAL: /var/folders/.../T/tmp.qqHnQhD99q is not under /private/tmp, refusing to proceed
test-planning-resolve-rules.sh    FATAL: /var/folders/.../T/tmp.Rhy4NDTvYN is not under /private/tmp, refusing to proceed
```

Both pass on this branch. CI never caught it because the runners are Ubuntu, where `TMPDIR` is `/tmp`.

Worth merging ahead of the other two split PRs — until it lands, those two suites abort locally on macOS for anyone running the full set.

## Also

`__pycache__/` and `*.pyc` added to `.gitignore`, and the frontmatter rule documented in `CLAUDE.md` so the `***` workaround for a leading horizontal rule is findable.

Verified: shellcheck clean repo-wide, frontmatter check green, all shell suites and python self-tests pass.
