### PR TITLE
fix(release-tools): abort on a failed forge CLI instead of shipping empty notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,30 @@ Entries are sorted by plugin version date, newest first.
 ### New Features
 
 - plan-review overlay: add an `orca` terminal backend to `launch-plan-review.sh`. Inside the Orca app (`TERM_PROGRAM=Orca`) the launcher had no matching branch, so the `ExitPlanMode` hook and `/planning:make` interactive review fell through to "no overlay terminal available" even with revdiff installed. The new branch opens revdiff in a new terminal tab via the orca CLI (`terminal create --command --focus`, pinned to the caller's worktree card through `ORCA_WORKTREE_ID`), blocks on a sentinel file until revdiff exits, then closes the tab with `terminal close --tab`. A sentinel is needed because `terminal create --command` runs inside an interactive shell that stays open after the command, so `terminal wait --for exit` never fires
+## release-tools v2.0.5 - 2026-08-20
+
+### Bug Fixes
+
+- `get-notes.sh` aborts when the forge CLI fails instead of shipping release notes with every PR entry missing. The CLI sat at the head of a `cli | jq | while` pipeline, so the script's exit status was the loop's — always 0 — and the CLI's own diagnostics went to `/dev/null`. `gh` missing, unauthenticated, rate-limited or pointed at the wrong repository all read as "this release has no PRs", and the workflow wrote those notes to the changelog and published the release with nothing indicating a failure. The Gitea branch was worse: a missing `tea` was wrapped in `command -v` with no `else`, a completely silent no-op. This is the same exit-0 hole the v2.0.4 unknown-platform guard closed, reached by the far more common route
+- `get-notes.sh` reports a `jq` failure too. `jq` is not installed by default on macOS, and a forge that renames a JSON field fails the same way — both drained the pipeline and left notes that listed no PRs
+- `get-notes.sh` initialises `tag_date` unconditionally. It was only ever assigned inside `if [ -n "$last_tag" ]`, so in an untagged repository it kept whatever an inherited environment variable of that name held and filtered PRs against it. The tag-date fallback also gained a `|| true`, since under `set -e` a git failure there killed the run with a bare exit code and no message
+- `SKILL.md` tells the agent that the helpers exit non-zero with the reason on stderr, and to abort rather than continue with an empty value. The Scripts block documented only what each helper prints on stdout, so the failures above had no documented consequence even once they were loud. Partly addresses `docs/backlog/release-skill-never-tells-agent-to-abort.md`
+
+### Other
+
+- `tests/test-release-tools.sh` covers a failing forge CLI on all three platforms and a failing `jq`, asserting a non-zero exit, empty stdout, and a diagnostic naming the tool — the previous commit-grouping tests stubbed `gh` as always-failing and asserted success, which locked the old behaviour in
+
+## release-tools v2.0.4 - 2026-08-20
+
+### Bug Fixes
+
+- `get-notes.sh` no longer drops PRs merged just after the last tag. The cutoff came from `git log --format=%aI`, which keeps the tag author's local UTC offset, while the forge APIs report merge times in UTC — and `jq` compares the two as plain strings. For a tagger at `+02:00` every PR merged within two hours after the tag compared as older than it and vanished from the release notes. The tag date is now rendered in UTC with the same `Z` suffix the APIs use
+- `get-notes.sh` takes the cutoff from the tag's own date rather than the tagged commit's author date. An author date survives rebases and cherry-picks, so it can sit days before the tag that points at it — and every PR merged in that window got re-listed in the next release's notes, having already shipped in the previous one. The date now comes from `git for-each-ref --format=%(creatordate:…)`, which is the tagger time for an annotated tag and the committer time for a lightweight one
+- `get-notes.sh` rejects an unknown platform. Anything other than `github`, `gitlab` or `gitea` fell through all three collection branches and returned commit-only notes with exit 0, which reads as a successful run that simply found no PRs
+
+### Other
+
+- extended `tests/test-release-tools.sh` to cover the paths these fixes touch: the `glab repo view` fallback for self-hosted GitLab, GitLab and Gitea PR collection (whose `jq` field names had never been exercised, so a typo in either produced empty notes silently), an unknown platform, the tag-date cutoff against merge times half an hour either side of the tag, and a tag created hours after its commit was authored. The forge CLIs are stubbed so results depend on neither the network nor what is installed
 
 ## release-tools v2.0.3 - 2026-08-19
 

--- a/docs/backlog/release-skill-never-tells-agent-to-abort.md
+++ b/docs/backlog/release-skill-never-tells-agent-to-abort.md
@@ -25,6 +25,11 @@ Partly mitigated by PR #44: `var=$(cmd)` propagates the substitution's exit stat
 surfaces both a non-zero code and the stderr text to the agent. Before that PR the error text was captured
 *into* `$platform`, which was strictly worse.
 
+Partly landed: the Scripts block now carries the exit-non-zero/abort line, added
+alongside the `get-notes.sh` forge-CLI failure fix (the failure it describes became
+reachable and loud there). Steps 2, 5 and the `:55-57` echo-without-abort shape are
+untouched.
+
 Open and unresolved: `plugins/release-tools/skills/last-tag/SKILL.md:20` says "**Important**: Avoid `$()`
 command substitution in Bash tool - use sequential steps", while this skill's entire workflow is built on
 `$()` captures. One plugin ships two contradictory conventions. If that note reflects a real limitation the

--- a/plugins/release-tools/.claude-plugin/plugin.json
+++ b/plugins/release-tools/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "release-tools",
   "description": "Release workflow tools - auto-versioning, release notes, changelog updates",
-  "version": "2.0.3",
+  "version": "2.0.5",
   "author": {
     "name": "Umputun"
   },

--- a/plugins/release-tools/skills/new/SKILL.md
+++ b/plugins/release-tools/skills/new/SKILL.md
@@ -21,6 +21,12 @@ Helper scripts in skill's `scripts/` directory (use `${CLAUDE_PLUGIN_ROOT}` for 
 - `calc-version.sh <type>` - outputs new version (e.g., `v1.2.3`)
 - `get-notes.sh <platform>` - outputs release notes (PRs/MRs or commits)
 
+Every helper exits non-zero and prints the reason on stderr. If any of Steps 2, 5 or 6
+fails, report that text to the user and **abort the workflow** - do not continue with an
+empty value. `get-notes.sh` in particular fails when the forge CLI is missing,
+unauthenticated or rate-limited; continuing there publishes a release whose notes list
+none of its PRs.
+
 ## Workflow
 
 ### Step 1: Ask Release Type

--- a/plugins/release-tools/skills/new/scripts/get-notes.sh
+++ b/plugins/release-tools/skills/new/scripts/get-notes.sh
@@ -13,15 +13,39 @@ if [ -z "$platform" ]; then
     exit 1
 fi
 
+# reject anything else rather than falling through every branch below and returning
+# commit-only notes with exit 0, which reads as a successful run that just found no PRs
+case "$platform" in
+    github|gitlab|gitea) ;;
+    *)
+        echo "error: unknown platform: $platform (expected github, gitlab or gitea)" >&2
+        exit 1
+        ;;
+esac
+
 # fetch tags from remote to ensure we have the latest
 git fetch origin --tags 2>/dev/null || true
 
 # get last tag
 last_tag=$(git describe --tags --abbrev=0 --match "v*" 2>/dev/null || echo "")
 
-# get tag date in UTC ISO format (empty if no tag)
+# get tag date in UTC (empty if no tag). jq compares these timestamps as strings, and
+# the forge APIs report merge times in UTC with a 'Z' suffix, so the tag date must be
+# rendered the same way. %aI would keep the author's local offset, which makes the
+# string compare wrong by that offset -- PRs merged just after the tag get dropped.
+# creatordate is the tag's own time (tagger time for annotated tags, committer time for
+# lightweight ones); the tagged commit's *author* date survives rebases and cherry-picks
+# and can predate the tag by days, which re-lists already-released PRs
+# initialised unconditionally: an untagged repo would otherwise read whatever an
+# inherited environment variable named tag_date held and filter PRs against it
+tag_date=""
 if [ -n "$last_tag" ]; then
-    tag_date=$(git log -1 --format=%aI "$last_tag" 2>/dev/null)
+    tag_date=$(TZ=UTC git for-each-ref --format='%(creatordate:format-local:%Y-%m-%dT%H:%M:%SZ)' "refs/tags/$last_tag" 2>/dev/null)
+    if [ -z "$tag_date" ]; then
+        # || true: set -e would otherwise kill the run with git's bare exit code and no
+        # message if the tag resolves for describe but not for log
+        tag_date=$(TZ=UTC git log -1 --date=format-local:%Y-%m-%dT%H:%M:%SZ --format=%cd "$last_tag" 2>/dev/null) || true
+    fi
 fi
 
 # temp files for collecting entries
@@ -29,7 +53,10 @@ features=$(mktemp)
 improvements=$(mktemp)
 fixes=$(mktemp)
 other=$(mktemp)
-trap 'rm -f "$features" "$improvements" "$fixes" "$other"' EXIT
+forge_out=$(mktemp)
+forge_err=$(mktemp)
+shaped=$(mktemp)
+trap 'rm -f "$features" "$improvements" "$fixes" "$other" "$forge_out" "$forge_err" "$shaped"' EXIT
 
 # categorize entry by conventional commit prefix
 # usage: categorize "description" "suffix"
@@ -58,53 +85,65 @@ categorize() {
     fi
 }
 
-# collect PRs/MRs
+# run a forge CLI, collecting its output, and abort when it fails. at the head of a
+# `cli | jq | while` pipeline the CLI's exit status is discarded (a pipeline reports
+# only its last command) and its diagnostics went to /dev/null, so a missing,
+# unauthenticated or rate-limited CLI read as "this release has no PRs" -- the same
+# silent exit-0 hole the unknown-platform guard above closes, by the far more common
+# route. an absent binary lands here too: bash reports 127 with its own message
+run_forge() {
+    if ! "$@" >"$forge_out" 2>"$forge_err"; then
+        echo "error: $1 failed: $(cat "$forge_err")" >&2
+        exit 1
+    fi
+}
+
+# feed collected PR/MR JSON through jq and categorize each entry
+# usage: collect_prs <jq args...>
+# jq's exit status is checked too: an absent jq (not installed by default on macOS)
+# would otherwise drain the pipeline and leave the same "no PRs" notes. it does not
+# catch a forge renaming a field -- jq reads a missing key as null and still exits 0,
+# so the row is either dropped by a select() or interpolated into the entry as the
+# text "null". only a type change errors out. the field names are pinned by test 12b
+# in tests/test-release-tools.sh instead
+collect_prs() {
+    if ! jq -r "$@" <"$forge_out" >"$shaped" 2>"$forge_err"; then
+        echo "error: jq failed to shape the $platform PR list: $(cat "$forge_err")" >&2
+        exit 1
+    fi
+    while IFS=$'\t' read -r title suffix; do
+        categorize "$title" "$suffix"
+    done <"$shaped"
+}
+
+# collect PRs/MRs.
+# the $date inside each filter is a jq variable bound by --arg in collect_prs, not a
+# shell expansion -- the directive covers the whole if-statement below
+# shellcheck disable=SC2016
 if [ "$platform" = "github" ]; then
     if [ -n "$tag_date" ]; then
-        gh pr list --state merged --limit 50 --json number,title,mergedAt,author 2>/dev/null | \
-            jq -r --arg date "$tag_date" \
-            '.[] | select(.mergedAt > $date) | "\(.title)\t#\(.number) @\(.author.login)"' | \
-            while IFS=$'\t' read -r title suffix; do
-                categorize "$title" "$suffix"
-            done
+        run_forge gh pr list --state merged --limit 50 --json number,title,mergedAt,author
+        collect_prs --arg date "$tag_date" \
+            '.[] | select(.mergedAt > $date) | "\(.title)\t#\(.number) @\(.author.login)"'
     else
-        gh pr list --state merged --limit 20 --json number,title,author 2>/dev/null | \
-            jq -r '.[] | "\(.title)\t#\(.number) @\(.author.login)"' | \
-            while IFS=$'\t' read -r title suffix; do
-                categorize "$title" "$suffix"
-            done
+        run_forge gh pr list --state merged --limit 20 --json number,title,author
+        collect_prs '.[] | "\(.title)\t#\(.number) @\(.author.login)"'
     fi
 elif [ "$platform" = "gitlab" ]; then
+    run_forge glab mr list --merged -F json
     if [ -n "$tag_date" ]; then
-        glab mr list --merged -F json 2>/dev/null | \
-            jq -r --arg date "$tag_date" \
-            '.[] | select(.merged_at > $date) | "\(.title)\t!\(.iid) @\(.author.username)"' | \
-            while IFS=$'\t' read -r title suffix; do
-                categorize "$title" "$suffix"
-            done
+        collect_prs --arg date "$tag_date" \
+            '.[] | select(.merged_at > $date) | "\(.title)\t!\(.iid) @\(.author.username)"'
     else
-        glab mr list --merged -F json 2>/dev/null | \
-            jq -r '.[] | "\(.title)\t!\(.iid) @\(.author.username)"' | \
-            while IFS=$'\t' read -r title suffix; do
-                categorize "$title" "$suffix"
-            done
+        collect_prs '.[] | "\(.title)\t!\(.iid) @\(.author.username)"'
     fi
 elif [ "$platform" = "gitea" ]; then
-    if command -v tea &>/dev/null; then
-        if [ -n "$tag_date" ]; then
-            tea pr list --state merged --output json 2>/dev/null | \
-                jq -r --arg date "$tag_date" \
-                '.[] | select(.merged > $date) | "\(.title)\t#\(.index) @\(.user.login)"' | \
-                while IFS=$'\t' read -r title suffix; do
-                    categorize "$title" "$suffix"
-                done
-        else
-            tea pr list --state merged --output json 2>/dev/null | \
-                jq -r '.[] | "\(.title)\t#\(.index) @\(.user.login)"' | \
-                while IFS=$'\t' read -r title suffix; do
-                    categorize "$title" "$suffix"
-                done
-        fi
+    run_forge tea pr list --state merged --output json
+    if [ -n "$tag_date" ]; then
+        collect_prs --arg date "$tag_date" \
+            '.[] | select(.merged > $date) | "\(.title)\t#\(.index) @\(.user.login)"'
+    else
+        collect_prs '.[] | "\(.title)\t#\(.index) @\(.user.login)"'
     fi
 fi
 

--- a/tests/test-release-tools.sh
+++ b/tests/test-release-tools.sh
@@ -94,6 +94,21 @@ assert_contains() {
     fi
 }
 
+assert_matches() {
+    local test_name="$1"
+    local haystack="$2"
+    local pattern="$3"
+    if [[ "$haystack" =~ $pattern ]]; then
+        echo "  PASS: $test_name"
+        passed=$((passed + 1))
+    else
+        echo "  FAIL: $test_name"
+        echo "    expected to match: $(printf '%q' "$pattern")"
+        echo "    actual:            $(printf '%q' "$haystack")"
+        failed=$((failed + 1))
+    fi
+}
+
 assert_not_contains() {
     local test_name="$1"
     local haystack="$2"
@@ -260,6 +275,19 @@ assert_exit_nonzero "detect-platform/unknown: exits non-zero" "$cap_rc"
 assert_output "detect-platform/unknown: no platform on stdout" "" "$cap_out"
 assert_contains "detect-platform/unknown: names the remote on stderr" "$cap_err" "unknown platform for https://git.example.invalid/group/project.git"
 
+# test 7b: unrecognised remote but `glab repo view` succeeds -> gitlab.
+# the only self-hosted-GitLab detection path; every other test stubs glab to fail,
+# which leaves this branch unexercised and free to break silently
+echo ""
+echo "test 7b: unrecognised remote + working glab -> gitlab"
+GLAB_OK_DIR="$(mk_tmp)"
+printf '#!/bin/sh\nexit 0\n' >"$GLAB_OK_DIR/glab"
+chmod +x "$GLAB_OK_DIR/glab"
+DP_SELF_HOSTED="$(make_repo_with_origin "https://git.example.invalid/group/project.git")"
+run_capture "$DP_SELF_HOSTED" env PATH="$GLAB_OK_DIR:$STUB_PATH" bash "$DETECT_PLATFORM"
+assert_output "detect-platform/self-hosted-gitlab: rc" "0" "$cap_rc"
+assert_output "detect-platform/self-hosted-gitlab: gitlab on stdout" "gitlab" "$cap_out"
+
 # test 8: no origin remote -> diagnostic on stderr, nothing on stdout
 echo ""
 echo "test 8: no origin remote -> error"
@@ -285,9 +313,28 @@ echo ""
 echo "testing get-notes.sh"
 echo "===================="
 
-# test 9: untagged repo -> commits grouped by conventional prefix
-echo ""
-echo "test 9: untagged repo -> commits grouped by prefix"
+# get-notes.sh now aborts when the forge CLI or jq fails, so the always-failing stubs
+# above no longer work for the notes tests. this stub reports "no merged PRs" instead,
+# which is what the commit-only tests are actually about
+STUB_EMPTY_DIR="$(mk_tmp)"
+for tool in gh glab tea; do
+    printf '#!/bin/sh\necho "[]"\n' >"$STUB_EMPTY_DIR/$tool"
+    chmod +x "$STUB_EMPTY_DIR/$tool"
+done
+STUB_EMPTY_PATH="$STUB_EMPTY_DIR:$PATH"
+
+# every notes test now needs a real jq: get-notes.sh shapes the forge JSON with it and
+# reports a jq failure rather than silently emitting notes with no PRs, so stubbing jq
+# as well would leave nothing under test. tests 13-16 exit before jq and run regardless
+JQ_AVAILABLE=0
+if command -v jq >/dev/null 2>&1; then
+    JQ_AVAILABLE=1
+else
+    echo ""
+    echo "SKIP: jq not installed, skipping the notes-content tests"
+fi
+
+# used by tests 13 and 14 as well, so it is scaffolded outside the jq guard
 GN_NO_TAG="$(mk_tmp)"
 make_git_repo "$GN_NO_TAG"
 (
@@ -297,9 +344,16 @@ make_git_repo "$GN_NO_TAG"
     commit_msg "chore: tidy up scripts"
     commit_msg "unprefixed subject line"
 )
-output="$(cd "$GN_NO_TAG" && PATH="$STUB_PATH" bash "$GET_NOTES" github)"
+
+if [ "$JQ_AVAILABLE" -eq 1 ]; then
+# test 9: untagged repo -> commits grouped by conventional prefix
+echo ""
+echo "test 9: untagged repo -> commits grouped by prefix"
+output="$(cd "$GN_NO_TAG" && PATH="$STUB_EMPTY_PATH" bash "$GET_NOTES" github)"
 assert_contains "get-notes/no-tag: features section" "$output" "**New Features**"
 assert_contains "get-notes/no-tag: feat entry loses its prefix" "$output" "- add plan annotations"
+# the suffix is part of the format: without it the entry names no commit
+assert_matches "get-notes/no-tag: commit entry carries the short hash" "$output" '- add plan annotations [0-9a-f]{7}'
 assert_contains "get-notes/no-tag: fixes section" "$output" "**Bug Fixes**"
 assert_contains "get-notes/no-tag: fix entry loses prefix and scope" "$output" "- stop dropping the exit code"
 assert_contains "get-notes/no-tag: improvements section" "$output" "**Improvements**"
@@ -318,21 +372,10 @@ make_git_repo "$GN_TAGGED"
     git tag v1.0.0
     commit_msg "fix: landed after the tag"
 )
-output="$(cd "$GN_TAGGED" && PATH="$STUB_PATH" bash "$GET_NOTES" github)"
+output="$(cd "$GN_TAGGED" && PATH="$STUB_EMPTY_PATH" bash "$GET_NOTES" github)"
 assert_contains "get-notes/tagged: post-tag commit included" "$output" "- landed after the tag"
 assert_not_contains "get-notes/tagged: pre-tag commit excluded" "$output" "shipped in the last release"
 
-# tests 11 and 12 need a real jq: get-notes.sh shapes the forge JSON with it,
-# and stubbing jq as well would leave nothing under test
-JQ_AVAILABLE=0
-if command -v jq >/dev/null 2>&1; then
-    JQ_AVAILABLE=1
-else
-    echo ""
-    echo "SKIP: jq not installed, skipping PR collection tests"
-fi
-
-if [ "$JQ_AVAILABLE" -eq 1 ]; then
     # gh stub returning two merged PRs: one merged far in the future (after any
     # tag this suite creates) and one merged in 1970 (before it)
     STUB_PR_DIR="$(mk_tmp)"
@@ -348,19 +391,109 @@ STUB
     chmod +x "$STUB_PR_DIR/gh"
     STUB_PR_PATH="$STUB_PR_DIR:$PATH"
 
-    # test 11: untagged repo -> every merged PR is listed with number and author
+    # test 11: untagged repo -> every merged PR is listed with number and author.
+    # own repo, so reordering or editing the commit tests above cannot change this
     echo ""
     echo "test 11: untagged repo -> merged PRs listed with number and author"
-    output="$(cd "$GN_NO_TAG" && PATH="$STUB_PR_PATH" bash "$GET_NOTES" github)"
+    GN_PRS="$(mk_tmp)"
+    make_git_repo "$GN_PRS"
+    output="$(cd "$GN_PRS" && PATH="$STUB_PR_PATH" bash "$GET_NOTES" github)"
     assert_contains "get-notes/prs: feat PR entry" "$output" "- add user authentication #45 @someone"
     assert_contains "get-notes/prs: fix PR entry" "$output" "- correct the login timeout #12 @other"
 
-    # test 12: tagged repo -> PRs merged before the tag are dropped
+    # test 12: tagged repo -> PRs merged before the tag are dropped. the tag is
+    # authored at +02:00 and the PRs are merged half an hour either side of that
+    # instant, so the comparison has to normalise both sides to UTC. millennia-apart
+    # stub dates would compare correctly under any offset and prove nothing
     echo ""
     echo "test 12: tagged repo -> PRs merged before the tag are dropped"
-    output="$(cd "$GN_TAGGED" && PATH="$STUB_PR_PATH" bash "$GET_NOTES" github)"
-    assert_contains "get-notes/prs-tagged: post-tag PR included" "$output" "- add user authentication #45 @someone"
+    GN_PRS_TAGGED="$(mk_tmp)"
+    make_git_repo "$GN_PRS_TAGGED"
+    (
+        cd "$GN_PRS_TAGGED"
+        GIT_AUTHOR_DATE="2026-08-20T01:00:00+02:00" \
+            GIT_COMMITTER_DATE="2026-08-20T01:00:00+02:00" \
+            commit_msg "feat: shipped in the last release"
+        git tag v1.0.0
+    )
+    STUB_TZ_DIR="$(mk_tmp)"
+    cat >"$STUB_TZ_DIR/gh" <<'STUB'
+#!/bin/sh
+cat <<'JSON'
+[
+  {"number":45,"title":"feat: merged half an hour after the tag","mergedAt":"2026-08-19T23:30:00Z","author":{"login":"someone"}},
+  {"number":12,"title":"fix: merged half an hour before the tag","mergedAt":"2026-08-19T22:30:00Z","author":{"login":"other"}}
+]
+JSON
+STUB
+    chmod +x "$STUB_TZ_DIR/gh"
+    output="$(cd "$GN_PRS_TAGGED" && PATH="$STUB_TZ_DIR:$PATH" bash "$GET_NOTES" github)"
+    assert_contains "get-notes/prs-tagged: post-tag PR included" "$output" "- merged half an hour after the tag #45 @someone"
     assert_not_contains "get-notes/prs-tagged: pre-tag PR excluded" "$output" "#12 @other"
+
+    # test 12b: the gitlab and gitea branches read different JSON field names
+    # (merged_at/iid/author.username, merged/index/user.login) and were never
+    # exercised, so a typo in either jq expression produced empty notes silently.
+    # the repo is tagged so both take their tagged arm -- merged_at and merged
+    # appear only in the select() there, and a renamed key yields null, which
+    # compares false against the date and drops every row while jq still exits 0
+    echo ""
+    echo "test 12b: gitlab and gitea PR collection"
+    STUB_FORGE_DIR="$(mk_tmp)"
+    cat >"$STUB_FORGE_DIR/glab" <<'STUB'
+#!/bin/sh
+cat <<'JSON'
+[
+  {"title":"feat: add the gitlab path","iid":7,"merged_at":"2999-01-01T00:00:00Z","author":{"username":"glabuser"}}
+]
+JSON
+STUB
+    cat >"$STUB_FORGE_DIR/tea" <<'STUB'
+#!/bin/sh
+cat <<'JSON'
+[
+  {"title":"fix: add the gitea path","index":9,"merged":"2999-01-01T00:00:00Z","user":{"login":"teauser"}}
+]
+JSON
+STUB
+    chmod +x "$STUB_FORGE_DIR/glab" "$STUB_FORGE_DIR/tea"
+    GN_FORGE="$(mk_tmp)"
+    make_git_repo "$GN_FORGE"
+    git -C "$GN_FORGE" tag v1.0.0
+    output="$(cd "$GN_FORGE" && PATH="$STUB_FORGE_DIR:$PATH" bash "$GET_NOTES" gitlab)"
+    assert_contains "get-notes/gitlab: MR entry with iid and username" "$output" "- add the gitlab path !7 @glabuser"
+    output="$(cd "$GN_FORGE" && PATH="$STUB_FORGE_DIR:$PATH" bash "$GET_NOTES" gitea)"
+    assert_contains "get-notes/gitea: PR entry with index and login" "$output" "- add the gitea path #9 @teauser"
+
+    # test 12c: the cutoff is when the release was cut, i.e. the tag's own date --
+    # not the tagged commit's author date, which survives rebases and cherry-picks
+    # and here predates the tag by six hours. a PR merged inside that window shipped
+    # in the previous release and must not be listed again
+    echo ""
+    echo "test 12c: cutoff comes from the tag's date, not the commit's author date"
+    GN_ANNOTATED="$(mk_tmp)"
+    make_git_repo "$GN_ANNOTATED"
+    (
+        cd "$GN_ANNOTATED"
+        GIT_AUTHOR_DATE="2026-08-19T20:00:00Z" \
+            GIT_COMMITTER_DATE="2026-08-19T20:00:00Z" \
+            commit_msg "feat: shipped in the last release"
+        GIT_COMMITTER_DATE="2026-08-20T02:00:00Z" git tag -a v1.0.0 -m "release v1.0.0"
+    )
+    STUB_TAGDATE_DIR="$(mk_tmp)"
+    cat >"$STUB_TAGDATE_DIR/gh" <<'STUB'
+#!/bin/sh
+cat <<'JSON'
+[
+  {"number":71,"title":"feat: merged after the release was cut","mergedAt":"2026-08-20T03:00:00Z","author":{"login":"someone"}},
+  {"number":70,"title":"fix: merged before the release was cut","mergedAt":"2026-08-19T23:00:00Z","author":{"login":"other"}}
+]
+JSON
+STUB
+    chmod +x "$STUB_TAGDATE_DIR/gh"
+    output="$(cd "$GN_ANNOTATED" && PATH="$STUB_TAGDATE_DIR:$PATH" bash "$GET_NOTES" github)"
+    assert_contains "get-notes/tag-date: post-release PR included" "$output" "- merged after the release was cut #71 @someone"
+    assert_not_contains "get-notes/tag-date: pre-release PR excluded" "$output" "#70 @other"
 fi
 
 # test 13: missing platform argument -> error
@@ -370,6 +503,48 @@ run_capture "$GN_NO_TAG" env PATH="$STUB_PATH" bash "$GET_NOTES"
 assert_exit_nonzero "get-notes/no-arg: exits non-zero" "$cap_rc"
 assert_output "get-notes/no-arg: no notes on stdout" "" "$cap_out"
 assert_contains "get-notes/no-arg: explains the usage on stderr" "$cap_err" "platform required"
+
+# test 14: unrecognised platform -> error, not commit-only notes.
+# falling through every branch returns exit 0 with notes that silently list no PRs
+echo ""
+echo "test 14: unrecognised platform -> error"
+run_capture "$GN_NO_TAG" env PATH="$STUB_PATH" bash "$GET_NOTES" bitbucket
+assert_exit_nonzero "get-notes/bad-platform: exits non-zero" "$cap_rc"
+assert_output "get-notes/bad-platform: no notes on stdout" "" "$cap_out"
+assert_contains "get-notes/bad-platform: names the platform on stderr" "$cap_err" "unknown platform: bitbucket"
+
+# test 15: a failing forge CLI aborts instead of emitting commit-only notes. the CLI sat
+# at the head of a `cli | jq | while` pipeline, so its exit status was discarded and its
+# stderr went to /dev/null -- gh missing, unauthenticated or rate-limited read as "this
+# release has no PRs" and shipped notes with every PR entry silently absent. the gitea
+# case also had no `else` for an absent tea at all
+echo ""
+echo "test 15: failing forge CLI -> error, not commit-only notes"
+for spec in "github:gh" "gitlab:glab" "gitea:tea"; do
+    forge="${spec%%:*}"
+    cli="${spec##*:}"
+    run_capture "$GN_NO_TAG" env PATH="$STUB_PATH" bash "$GET_NOTES" "$forge"
+    assert_exit_nonzero "get-notes/$forge-cli-fails: exits non-zero" "$cap_rc"
+    assert_output "get-notes/$forge-cli-fails: no notes on stdout" "" "$cap_out"
+    assert_contains "get-notes/$forge-cli-fails: names the CLI on stderr" "$cap_err" "error: $cli failed"
+    # the commit section is never reached, so no entry leaks through as "the notes"
+    assert_not_contains "get-notes/$forge-cli-fails: no commit entries" "$cap_out" "add plan annotations"
+done
+
+# test 16: a failing jq aborts too -- jq is not installed by default on macOS, and it
+# drained the pipeline and left notes that listed no PRs. a renamed field is not this
+# case: jq reads a missing key as null and exits 0, so only a type change trips this
+# check; test 12b pins the field names
+echo ""
+echo "test 16: failing jq -> error, not commit-only notes"
+STUB_BADJQ_DIR="$(mk_tmp)"
+printf '#!/bin/sh\necho "[]"\n' >"$STUB_BADJQ_DIR/gh"
+printf '#!/bin/sh\necho "jq: no such field" >&2\nexit 3\n' >"$STUB_BADJQ_DIR/jq"
+chmod +x "$STUB_BADJQ_DIR/gh" "$STUB_BADJQ_DIR/jq"
+run_capture "$GN_NO_TAG" env PATH="$STUB_BADJQ_DIR:$PATH" bash "$GET_NOTES" github
+assert_exit_nonzero "get-notes/jq-fails: exits non-zero" "$cap_rc"
+assert_output "get-notes/jq-fails: no notes on stdout" "" "$cap_out"
+assert_contains "get-notes/jq-fails: reports the jq failure on stderr" "$cap_err" "jq failed to shape"
 
 # summary
 echo ""


### PR DESCRIPTION
Split out of #43, which had accumulated three unrelated plugin releases under a title about issue #42. This half bumps release-tools 2.0.5 and is independent of the planning work.

The code is what four review rounds already covered there. The two test/comment fixes from the latest round are folded into the same commit.

## get-notes.sh aborts instead of shipping empty notes

The forge CLI sat at the head of a `cli | jq | while` pipeline, so the script's exit status was the loop's — always 0 — and the CLI's own diagnostics went to `/dev/null`. `gh` missing, unauthenticated, rate-limited or pointed at the wrong repository all read as "this release has no PRs", and the workflow wrote those notes to the changelog and published the release with nothing indicating a failure. The Gitea branch was worse: a missing `tea` was wrapped in `command -v` with no `else`, a silent no-op.

`jq` is checked too — not installed by default on macOS, same drained pipeline.

`tag_date` is now initialised unconditionally. It was only assigned inside `if [ -n "$last_tag" ]`, so in an untagged repository it kept whatever an inherited environment variable of that name held and filtered PRs against it.

`SKILL.md` tells the agent the helpers exit non-zero with the reason on stderr and to abort rather than continue with an empty value. Partly addresses `docs/backlog/release-skill-never-tells-agent-to-abort.md`.

## From the round-4 review

**test 12b now pins what its comment claims.** `GN_FORGE` had no tag, so `last_tag` was empty and both platforms took the untagged arms — `get-notes.sh:132` and `:140`, the `select(.merged_at > $date)` and `select(.merged > $date)` filters, were never reached. The comment named `merged_at`/`merged` as covered, and those keys appear *only* in the tagged arms. Fixed with `git tag v1.0.0` in the subshell; the stub merge dates were already 2999.

Mutation-tested both ways, renaming `.merged_at` in the tagged filter:

| | Result |
|---|---|
| With the tag | **FAIL** — 73 passed, 1 failed |
| Without it | **PASS** — 74 passed, 0 failed |

So the old test sailed past a renamed key, which is the silent empty-notes case this PR exists to close.

**Corrected the comments that overstate the jq exit check.** They credited it with catching "a field the forge renamed". Measured behaviour:

| Case | jq exit | Caught |
|---|---|---|
| jq absent | 127 | yes |
| Type change (`"str".login`) | 5 | yes |
| Renamed key in `select()` | 0 | no — row dropped |
| Renamed key in interpolation | 0 | no — emits literal `null` |
| Renamed nested parent | 0 | no — `null.login` is null |

One nuance beyond the review note: a rename does not always drain the pipeline. Inside `select()` it drops the row; inside the interpolation it emits the entry with `null` in it (`- add the gitlab path !null @glabuser`). Different symptom, same exit 0 — both are now described, since "drains the pipeline" alone makes the second case look impossible. Both comments point at test 12b as what actually pins the field names.

Deliberately not done, per the review: no per-platform schema validation, and no `[ -s ]` guard in `run_forge` — `tea` emitting `[]` for an empty list is unconfirmed, and false-aborting a first Gitea release is worse than the case it would prevent.

## Note

Two suites (`test-brainstorm-resolve-rules.sh`, `test-planning-resolve-rules.sh`) abort on macOS on this branch. That is pre-existing on master, not from this change — #49 carries the fix. Verified on a clean master worktree. Ubuntu CI is unaffected.

Verified: shellcheck clean, frontmatter green, release-tools suite 74/74.
