### PR TITLE
fix(workflow): scan ~/.claude/rules for memory-placement guidance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ This repo ships independent Claude Code plugins. Version headings use values fro
 
 Entries are sorted by plugin version date, newest first.
 
+## workflow v1.3.1 - 2026-09-07
+
+### Bug Fixes
+
+- learn: step 1 now also scans `~/.claude/rules/*.md` for memory-placement guidance
+
 ## planning v3.10.2 - 2026-09-07
 
 ### Bug Fixes

--- a/README.md
+++ b/README.md
@@ -383,7 +383,7 @@ Session workflow helpers for knowledge capture, confusion handling, course corre
 | skill | `/workflow:txt-copy` | Copy generated text content to clipboard |
 | skill | `/workflow:backlog` | Read, work, and maintain deferred-work items in `docs/backlog/` |
 
-**learn** — reviews conversation history, extracts strategic project knowledge (architecture patterns, conventions, operational insights), and saves selected items to the project CLAUDE.md. When `CLAUDE.local.md` is present, per-developer / per-checkout discoveries (machine-specific tooling, environment quirks) are routed there instead. Defers to any project-defined memory-placement guidance documented in `CLAUDE.md` or `.claude/rules/`. Uses granular selection via AskUserQuestion so the user picks exactly what to keep.
+**learn** — reviews conversation history, extracts strategic project knowledge (architecture patterns, conventions, operational insights), and saves selected items to the project CLAUDE.md. When `CLAUDE.local.md` is present, per-developer / per-checkout discoveries (machine-specific tooling, environment quirks) are routed there instead. Defers to any memory-placement guidance documented in the project or user `CLAUDE.md` or `.claude/rules/`. Uses granular selection via AskUserQuestion so the user picks exactly what to keep.
 
 **clarify** — activates on confusion signals ("I don't understand", "why is this happening", etc.). Investigates the actual codebase to determine whether the confusion stems from a misunderstanding or a real issue. If real, proceeds to plan mode for a fix.
 

--- a/plugins/workflow/.claude-plugin/plugin.json
+++ b/plugins/workflow/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "workflow",
   "description": "Session workflow helpers and deferred-work backlog - knowledge capture, confusion handling, course correction, clipboard copy, backlog items",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "author": {
     "name": "Umputun"
   },

--- a/plugins/workflow/skills/learn/SKILL.md
+++ b/plugins/workflow/skills/learn/SKILL.md
@@ -86,7 +86,7 @@ Ask yourself for each discovery:
 ## Workflow
 
 ### 1. Check for Existing Memory-Placement Guidance
-Before applying the routing rules below, scan the project's root `CLAUDE.md`, any `.claude/rules/*.md` files, and the user's global `~/.claude/CLAUDE.md` for documented memory-placement guidance — for example, a placement decision tree, an instruction to use a project-specific triage command, or specific destinations beyond `CLAUDE.md` / `CLAUDE.local.md`. If such guidance exists, defer to it: follow the documented workflow or place each discovery according to its rules instead of using this skill's defaults. The remaining steps apply only when no such guidance is found.
+Before applying the routing rules below, scan the project's root `CLAUDE.md`, any `.claude/rules/*.md` files, the user's global `~/.claude/CLAUDE.md`, and any `~/.claude/rules/*.md` files for documented memory-placement guidance — for example, a placement decision tree, an instruction to use a project-specific triage command, or specific destinations beyond `CLAUDE.md` / `CLAUDE.local.md`. If such guidance exists, defer to it: follow the documented workflow or place each discovery according to its rules instead of using this skill's defaults. The remaining steps apply only when no such guidance is found.
 
 ### 2. Check Existing Memory Content
 Read the current content of project `CLAUDE.md`, `CLAUDE.local.md` (if present), and the user's global `~/.claude/CLAUDE.md` to avoid duplication — including cross-project entries already captured in user memory.


### PR DESCRIPTION
Step 1 of the learn skill looks for memory-placement guidance in the project `CLAUDE.md`, in `.claude/rules/*.md`, and in the user's `~/.claude/CLAUDE.md`, but not in `~/.claude/rules/*.md`.

I keep my own knowledge-capture setup for projects as a user-level rule, and the skill does not pick it up. If this fits your vision for the skill, I would be very grateful to see it merged.